### PR TITLE
Refactor privacy notice dialog to return a Future

### DIFF
--- a/lib/modules/main/application/main_screen_provider.dart
+++ b/lib/modules/main/application/main_screen_provider.dart
@@ -53,11 +53,11 @@ class MainScreenLogic {
     }
   }
 
-  Future<void> checkAndShowPrivacyNotice(Function showDialog) async {
+  Future<void> checkAndShowPrivacyNotice(Future<void> Function() showDialog) async {
     final prefs = await SharedPreferences.getInstance();
     final bool privacyNoticeShown = prefs.getBool('privacy_notice_shown') ?? false;
     if (!privacyNoticeShown) {
-      showDialog();
+      return showDialog();
     }
   }
 

--- a/lib/modules/main/presentation/screens/main_screen.dart
+++ b/lib/modules/main/presentation/screens/main_screen.dart
@@ -136,8 +136,8 @@ class _MainScreenState extends ConsumerState<MainScreen> {
     _secretTapHandler.handleSecretTap(context);
   }
 
-  void _showPrivacyNoticeDialog() {
-    PrivacyNoticeDialog.show(
+  Future<void> _showPrivacyNoticeDialog() {
+    return PrivacyNoticeDialog.show(
       context,
       () async {
         if (ref.context.mounted) {


### PR DESCRIPTION
### Change Description
Returns `PrivacyNoticeDialog.show`'s future so the app waits until the user accepts the privacy terms before checking for updates and showing the update dialog. This fixes the issue where both dialogs could be open at the same time

---

### Related Platforms
> Which platforms are affected by your changes? Check only the ones you actually tested.

- [ ] Android
- [ ] iOS
- [ ] iPad
- [x] Windows
- [ ] Linux
- [ ] Android TV
- [ ] OpenWrt

---

### Verification Checklist
> Make sure the things you checked actually work. It's okay if you didn't test everything.

- [x] Project builds successfully
- [x] App runs without crashes on tested platforms
- [x] VPN connection works correctly
- [x] No obvious regressions observed
- [x] Documentation updated (if needed)

---

### Optional (for bigger changes)
- [ ] Added or updated unit / E2E tests
- [ ] Checked security and edge cases

---

### Related Links
Closes #5 .
