### PR TITLE
Update analysis_options.yaml to exclude generated files from analyzer

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -26,3 +26,8 @@ linter:
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options
+
+analyzer:
+  exclude:
+    - lib/**.freezed.dart
+    - lib/**.g.dart


### PR DESCRIPTION
### Change Description
Generated files such as `*.freezed.dart`, `*.g.dart`, and other build outputs are machine-generated and should not be manually modified. Including them in analyzer checks produces unnecessary warnings and lint noise and slows down analysis.