### PR TITLE
fix(linux): fix black screen on startup and AppImage launch

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -77,7 +77,6 @@ jobs:
             libgstreamer-plugins-base1.0-dev \
             libsecret-1-dev \
             libfuse2 \
-            libfuse2t64 \
             plocate \
             rpm
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,7 +78,11 @@ jobs:
             libsecret-1-dev \
             libfuse2 \
             libfuse2t64 \
+            plocate \
             rpm
+
+      - name: Build locate database (needed by fastforge AppImage `include`)
+        run: sudo updatedb
 
       - name: Install appimagetool
         run: |

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,7 +4,13 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "defyxvpn")
+#
+# IMPORTANT: This MUST match the `name:` field in pubspec.yaml (defyx_vpn).
+# fastforge's AppImage maker generates AppRun/.desktop using the pubspec name
+# (appName), while the built executable is named after BINARY_NAME. If the two
+# differ, the AppImage's AppRun calls a binary that does not exist and fails
+# with "No such file or directory".
+set(BINARY_NAME "defyx_vpn")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
 set(APPLICATION_ID "de.unboundtech.defyxvpn")

--- a/linux/packaging/appimage/make_config.yaml
+++ b/linux/packaging/appimage/make_config.yaml
@@ -26,3 +26,18 @@ keywords:
   - privacy
 categories:
   - Network
+
+# Shared libraries that must be bundled into the AppImage but are NOT picked up
+# automatically. fastforge only scans the .so files under AppDir/lib (plugins)
+# for their dependencies; it does not scan the main executable. The system tray
+# libs below are linked directly into the executable, so they have to be listed
+# here explicitly, together with their own runtime dependency chain. Without
+# this, the app fails on distros that don't ship appindicator (e.g. NixOS,
+# minimal/KDE installs) with:
+#   "libayatana-appindicator3.so.1: cannot open shared object file"
+# NOTE: these are resolved via `locate`, so CI must run `updatedb` first.
+include:
+  - libayatana-appindicator3.so.1
+  - libayatana-indicator3.so.7
+  - libdbusmenu-gtk3.so.4
+  - libdbusmenu-glib.so.4

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -71,20 +71,12 @@ static void HandleTrayAction(SystemTray::TrayAction action)
     {
       g_settings_manager->SetAutoConnect(g_system_tray->GetAutoConnect());
 
-      if (g_flutter_view)
+      if (g_vpn_channel_handler)
       {
-        FlBinaryMessenger *messenger = fl_engine_get_binary_messenger(
-            fl_view_get_engine(g_flutter_view));
-        g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-        FlMethodChannel *channel = fl_method_channel_new(
-            messenger, "com.defyx.vpn", FL_METHOD_CODEC(codec));
-
         g_autoptr(FlValue) args = fl_value_new_map();
         fl_value_set_string_take(args, "value",
                                  fl_value_new_bool(g_system_tray->GetAutoConnect()));
-        fl_method_channel_invoke_method(channel, "setAutoConnect", args,
-                                        nullptr, nullptr, nullptr);
-        g_object_unref(channel);
+        g_vpn_channel_handler->InvokeMethod("setAutoConnect", fl_value_ref(args));
       }
     }
     break;
@@ -94,20 +86,12 @@ static void HandleTrayAction(SystemTray::TrayAction action)
     {
       g_settings_manager->SetStartMinimized(g_system_tray->GetStartMinimized());
 
-      if (g_flutter_view)
+      if (g_vpn_channel_handler)
       {
-        FlBinaryMessenger *messenger = fl_engine_get_binary_messenger(
-            fl_view_get_engine(g_flutter_view));
-        g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-        FlMethodChannel *channel = fl_method_channel_new(
-            messenger, "com.defyx.vpn", FL_METHOD_CODEC(codec));
-
         g_autoptr(FlValue) args = fl_value_new_map();
         fl_value_set_string_take(args, "value",
                                  fl_value_new_bool(g_system_tray->GetStartMinimized()));
-        fl_method_channel_invoke_method(channel, "setStartMinimized", args,
-                                        nullptr, nullptr, nullptr);
-        g_object_unref(channel);
+        g_vpn_channel_handler->InvokeMethod("setStartMinimized", fl_value_ref(args));
       }
     }
     break;
@@ -117,20 +101,12 @@ static void HandleTrayAction(SystemTray::TrayAction action)
     {
       g_settings_manager->SetForceClose(g_system_tray->GetForceClose());
 
-      if (g_flutter_view)
+      if (g_vpn_channel_handler)
       {
-        FlBinaryMessenger *messenger = fl_engine_get_binary_messenger(
-            fl_view_get_engine(g_flutter_view));
-        g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-        FlMethodChannel *channel = fl_method_channel_new(
-            messenger, "com.defyx.vpn", FL_METHOD_CODEC(codec));
-
         g_autoptr(FlValue) args = fl_value_new_map();
         fl_value_set_string_take(args, "value",
                                  fl_value_new_bool(g_system_tray->GetForceClose()));
-        fl_method_channel_invoke_method(channel, "setForceClose", args,
-                                        nullptr, nullptr, nullptr);
-        g_object_unref(channel);
+        g_vpn_channel_handler->InvokeMethod("setForceClose", fl_value_ref(args));
       }
     }
     break;
@@ -140,20 +116,12 @@ static void HandleTrayAction(SystemTray::TrayAction action)
     {
       g_settings_manager->SetSoundEffect(g_system_tray->GetSoundEffect());
 
-      if (g_flutter_view)
+      if (g_vpn_channel_handler)
       {
-        FlBinaryMessenger *messenger = fl_engine_get_binary_messenger(
-            fl_view_get_engine(g_flutter_view));
-        g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-        FlMethodChannel *channel = fl_method_channel_new(
-            messenger, "com.defyx.vpn", FL_METHOD_CODEC(codec));
-
         g_autoptr(FlValue) args = fl_value_new_map();
         fl_value_set_string_take(args, "value",
                                  fl_value_new_bool(g_system_tray->GetSoundEffect()));
-        fl_method_channel_invoke_method(channel, "setSoundEffect", args,
-                                        nullptr, nullptr, nullptr);
-        g_object_unref(channel);
+        g_vpn_channel_handler->InvokeMethod("setSoundEffect", fl_value_ref(args));
       }
     }
     break;
@@ -199,80 +167,44 @@ static void HandleTrayAction(SystemTray::TrayAction action)
 
   case SystemTray::TrayAction::OpenIntroduction:
     gtk_window_present(g_main_window);
-    if (g_flutter_view)
+    if (g_vpn_channel_handler)
     {
-      FlBinaryMessenger *messenger = fl_engine_get_binary_messenger(
-          fl_view_get_engine(g_flutter_view));
-      g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-      FlMethodChannel *channel = fl_method_channel_new(
-          messenger, "com.defyx.vpn", FL_METHOD_CODEC(codec));
-      fl_method_channel_invoke_method(channel, "openIntroduction", nullptr,
-                                      nullptr, nullptr, nullptr);
-      g_object_unref(channel);
+      g_vpn_channel_handler->InvokeMethod("openIntroduction", nullptr);
     }
     break;
 
   case SystemTray::TrayAction::OpenSpeedTest:
     gtk_window_present(g_main_window);
-    if (g_flutter_view)
+    if (g_vpn_channel_handler)
     {
-      FlBinaryMessenger *messenger = fl_engine_get_binary_messenger(
-          fl_view_get_engine(g_flutter_view));
-      g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-      FlMethodChannel *channel = fl_method_channel_new(
-          messenger, "com.defyx.vpn", FL_METHOD_CODEC(codec));
-      fl_method_channel_invoke_method(channel, "openSpeedTest", nullptr,
-                                      nullptr, nullptr, nullptr);
-      g_object_unref(channel);
+      g_vpn_channel_handler->InvokeMethod("openSpeedTest", nullptr);
     }
     break;
 
   case SystemTray::TrayAction::OpenLogs:
     gtk_window_present(g_main_window);
-    if (g_flutter_view)
+    if (g_vpn_channel_handler)
     {
-      FlBinaryMessenger *messenger = fl_engine_get_binary_messenger(
-          fl_view_get_engine(g_flutter_view));
-      g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-      FlMethodChannel *channel = fl_method_channel_new(
-          messenger, "com.defyx.vpn", FL_METHOD_CODEC(codec));
-      fl_method_channel_invoke_method(channel, "openLogs", nullptr,
-                                      nullptr, nullptr, nullptr);
-      g_object_unref(channel);
+      g_vpn_channel_handler->InvokeMethod("openLogs", nullptr);
     }
     break;
 
   case SystemTray::TrayAction::OpenPreferences:
     gtk_window_present(g_main_window);
-    if (g_flutter_view)
+    if (g_vpn_channel_handler)
     {
-      FlBinaryMessenger *messenger = fl_engine_get_binary_messenger(
-          fl_view_get_engine(g_flutter_view));
-      g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-      FlMethodChannel *channel = fl_method_channel_new(
-          messenger, "com.defyx.vpn", FL_METHOD_CODEC(codec));
-      fl_method_channel_invoke_method(channel, "openPreferences", nullptr,
-                                      nullptr, nullptr, nullptr);
-      g_object_unref(channel);
+      g_vpn_channel_handler->InvokeMethod("openPreferences", nullptr);
     }
     break;
 
   case SystemTray::TrayAction::ConnectionStatusClick:
     gtk_window_present(g_main_window);
-    if (g_flutter_view && g_system_tray)
+    if (g_vpn_channel_handler && g_system_tray)
     {
-      FlBinaryMessenger *messenger = fl_engine_get_binary_messenger(
-          fl_view_get_engine(g_flutter_view));
-      g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-      FlMethodChannel *channel = fl_method_channel_new(
-          messenger, "com.defyx.vpn", FL_METHOD_CODEC(codec));
-
       g_autoptr(FlValue) args = fl_value_new_map();
       fl_value_set_string_take(args, "status",
                                fl_value_new_string(g_system_tray->GetConnectionStatusText().c_str()));
-      fl_method_channel_invoke_method(channel, "handleConnectionStatusClick", args,
-                                      nullptr, nullptr, nullptr);
-      g_object_unref(channel);
+      g_vpn_channel_handler->InvokeMethod("handleConnectionStatusClick", fl_value_ref(args));
     }
     break;
 
@@ -397,20 +329,22 @@ static void my_application_activate(GApplication *application)
 
   defyx_core::LogMessage("my_application: System tray initialized");
 
-  // Initialize VPN channel handler with system tray
-  // We need to delay this until after the GTK main loop starts and Flutter engine is ready
-  g_idle_add([](gpointer data) -> gboolean {
-    auto* messenger = static_cast<FlBinaryMessenger*>(data);
-    
-    defyx_core::LogMessage("my_application: Setting up VPN channel handler (idle callback)");
-    
-    g_vpn_channel_handler = new VPNChannelHandler(messenger, g_main_window, g_system_tray);
-    g_vpn_channel_handler->SetupChannels();
-    
-    defyx_core::LogMessage("my_application: VPNChannelHandler channels setup complete (idle callback)");
-    
-    return FALSE; // Don't repeat
-  }, messenger);
+  // Initialize VPN channel handler with system tray.
+  //
+  // IMPORTANT: register the platform channels SYNCHRONOUSLY here, while we are
+  // still inside activate() and have NOT yet returned to the GTK main loop.
+  //
+  // The Dart entrypoint (main()) calls method-channel methods such as
+  // getSharedDirectory()/setCacheDir() on "com.defyx.vpn" very early, BEFORE
+  // runApp(). If the native method-call handler is registered late (e.g. via
+  // g_idle_add), those early calls arrive before any handler exists, are never
+  // responded to ("FlBinaryMessengerResponseHandle was not responded to"), the
+  // Dart Future never completes, main() blocks forever and runApp() is never
+  // reached -> permanent BLACK SCREEN. Registering synchronously here
+  // guarantees the handler is in place before the main loop dispatches any
+  // platform message from Dart.
+  g_vpn_channel_handler = new VPNChannelHandler(messenger, g_main_window, g_system_tray);
+  g_vpn_channel_handler->SetupChannels();
 
   // Load preferences from settings
   g_system_tray->SetLaunchOnStartup(g_settings_manager->IsLaunchOnStartupEnabled());
@@ -444,35 +378,25 @@ static void my_application_activate(GApplication *application)
 
   // Send initial sound effect setting to Flutter
   {
-    g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-    FlMethodChannel *channel = fl_method_channel_new(
-        messenger, "com.defyx.vpn", FL_METHOD_CODEC(codec));
-
     g_autoptr(FlValue) args = fl_value_new_map();
     fl_value_set_string_take(args, "value",
                              fl_value_new_bool(g_settings_manager->GetSoundEffect()));
-    fl_method_channel_invoke_method(channel, "setSoundEffect", args,
-                                    nullptr, nullptr, nullptr);
-    g_object_unref(channel);
+    g_vpn_channel_handler->InvokeMethod("setSoundEffect", fl_value_ref(args));
   }
 
   // Handle auto-connect
   if (g_system_tray->GetAutoConnect())
   {
-    std::thread([messenger]()
+    std::thread([]()
                 {
       std::this_thread::sleep_for(std::chrono::milliseconds(1000));
       
       g_idle_add([](gpointer data) -> gboolean {
-        FlBinaryMessenger* msg = static_cast<FlBinaryMessenger*>(data);
-        g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-        FlMethodChannel* channel = fl_method_channel_new(
-            msg, "com.defyx.vpn", FL_METHOD_CODEC(codec));
-        fl_method_channel_invoke_method(channel, "triggerAutoConnect", nullptr,
-                                        nullptr, nullptr, nullptr);
-        g_object_unref(channel);
+        if (g_vpn_channel_handler) {
+          g_vpn_channel_handler->InvokeMethod("triggerAutoConnect", nullptr);
+        }
         return FALSE;
-      }, messenger); })
+      }, nullptr); })
         .detach();
   }
 

--- a/linux/runner/settings_manager.cpp
+++ b/linux/runner/settings_manager.cpp
@@ -314,7 +314,7 @@ bool SettingsManager::SetLaunchOnStartup(bool enable)
         content << "Name=DefyxVPN\n";
         content << "Comment=DefyxVPN Application\n";
         content << "Exec=" << exe_path << " --startup\n";
-        content << "Icon=defyxvpn\n";
+        content << "Icon=defyx_vpn\n";
         content << "Terminal=false\n";
         content << "Categories=Network;VPN;\n";
         content << "StartupNotify=false\n";

--- a/linux/runner/vpn_channel_handler.cpp
+++ b/linux/runner/vpn_channel_handler.cpp
@@ -266,6 +266,20 @@ void VPNChannelHandler::SetupChannels()
     defyx_core::LogMessage("VPNChannelHandler::SetupChannels completed");
 }
 
+void VPNChannelHandler::InvokeMethod(const std::string &method, FlValue *args)
+{
+    if (method_channel_ == nullptr)
+    {
+        if (args != nullptr)
+            fl_value_unref(args);
+        return;
+    }
+    fl_method_channel_invoke_method(method_channel_, method.c_str(), args,
+                                    nullptr, nullptr, nullptr);
+    if (args != nullptr)
+        fl_value_unref(args);
+}
+
 void VPNChannelHandler::SetupStatusChannel()
 {
     g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();

--- a/linux/runner/vpn_channel_handler.h
+++ b/linux/runner/vpn_channel_handler.h
@@ -27,6 +27,13 @@ public:
     void SendStatus(const std::string &status);
     void SendProgress(const std::string &message);
 
+    // Invoke a method on the Dart side using the SINGLE persistent method
+    // channel. Creating throwaway FlMethodChannel objects on "com.defyx.vpn"
+    // re-registers (and on unref, removes) the messenger's handler for that
+    // channel name, which silently kills HandleMethodCall. Always invoke
+    // through this helper instead. Takes ownership of `args` (may be nullptr).
+    void InvokeMethod(const std::string &method, FlValue *args = nullptr);
+
 private:
     static void HandleMethodCall(FlMethodChannel *channel,
                                  FlMethodCall *method_call,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -221,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -873,26 +873,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1350,10 +1350,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
The VPN method channel handler was registered too late and got wiped by temporary channels, so the first call from main() (getSharedDirectory) never returned and runApp was never reached, leaving a black window. Now the channels are registered synchronously and all native > Dart calls go through the one persistent channel (this also fixes VPN control breaking after tray clicks).

AppImage fixes: renamed the binary to defyx_vpn so AppRun finds it, bundled libayatana-appindicator3 and its dependencies, and corrected the autostart icon name. :))
