### PR TITLE
feat(linux): add headless CLI client

### DIFF
--- a/.github/workflows/linux-cli.yml
+++ b/.github/workflows/linux-cli.yml
@@ -1,0 +1,58 @@
+name: Linux CLI
+
+on:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - ".github/workflows/linux-cli.yml"
+      - "linux/cli/**"
+      - "linux/runner/defyx_core.cpp"
+      - "linux/runner/defyx_core.h"
+      - "pubspec.yaml"
+  push:
+    branches:
+      - dev
+    paths:
+      - ".github/workflows/linux-cli.yml"
+      - "linux/cli/**"
+      - "linux/runner/defyx_core.cpp"
+      - "linux/runner/defyx_core.h"
+      - "pubspec.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            ninja-build \
+            pkg-config \
+            libjson-c-dev
+
+      - name: Configure
+        run: |
+          cmake -S linux/cli -B build/linux-cli -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TESTING=ON
+
+      - name: Build
+        run: cmake --build build/linux-cli
+
+      - name: Test
+        run: ctest --test-dir build/linux-cli --output-on-failure
+
+      - name: Smoke test
+        run: |
+          build/linux-cli/bin/defyxvpn-cli --version
+          build/linux-cli/bin/defyxvpn-cli --help

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -71,6 +71,7 @@ jobs:
             ninja-build \
             pkg-config \
             libgtk-3-dev \
+            libjson-c-dev \
             liblzma-dev \
             libayatana-appindicator3-dev \
             libgstreamer1.0-dev \
@@ -96,6 +97,25 @@ jobs:
           export PATH="$PATH":"$HOME/.pub-cache/bin"
           fastforge release --name=production
 
+      - name: Build headless Linux CLI
+        run: |
+          cmake -S linux/cli -B build/linux-cli -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TESTING=ON \
+            -DDEFYX_DXCORE_LIB="$GITHUB_WORKSPACE/linux/runner/libdxcore_amd64.so"
+          cmake --build build/linux-cli
+          ctest --test-dir build/linux-cli --output-on-failure
+
+          CLI_DIST="$GITHUB_WORKSPACE/build/linux-cli-dist"
+          mkdir -p "$CLI_DIST"
+          cp build/linux-cli/bin/defyxvpn-cli "$CLI_DIST/"
+          cp linux/runner/libdxcore_amd64.so "$CLI_DIST/"
+          cp linux/cli/README.md "$CLI_DIST/"
+          cp linux/cli/defyxvpn-cli.service "$CLI_DIST/"
+          cp linux/cli/defyxvpn-cli.env.example "$CLI_DIST/"
+          tar -C "$CLI_DIST" -czf \
+            "$GITHUB_WORKSPACE/build/DefyxVPN-CLI-Linux-x86_64.tar.gz" .
+
       - name: Rename Linux artifacts
         run: |
           shopt -s globstar nullglob
@@ -115,4 +135,5 @@ jobs:
             build/**/*.AppImage
             build/**/*.deb
             build/**/*.rpm
+            build/**/*.tar.gz
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ This will:
 - Clean pub cache
 - Build the IPA file
 
+### Headless Linux
+
+DefyxVPN also includes a terminal-only Linux client for servers, SSH sessions,
+containers, and systemd. It uses the same DXcore integration without requiring
+Flutter, GTK, a system tray, or a display server.
+
+Build instructions and service examples are available in
+[`linux/cli/README.md`](linux/cli/README.md).
+
 ## Usage
 
 1. Launch the app

--- a/linux/cli/CMakeLists.txt
+++ b/linux/cli/CMakeLists.txt
@@ -32,6 +32,7 @@ endfunction()
 add_library(defyx_cli_support STATIC
   src/cli_options.cpp
   src/flowline.cpp
+  src/health_check.cpp
   src/progress.cpp
   src/status_file.cpp
   src/tcp_forwarder.cpp

--- a/linux/cli/CMakeLists.txt
+++ b/linux/cli/CMakeLists.txt
@@ -1,0 +1,106 @@
+cmake_minimum_required(VERSION 3.13)
+project(defyxvpn_cli LANGUAGES C CXX)
+
+include(CTest)
+include(GNUInstallDirs)
+
+find_package(PkgConfig REQUIRED)
+find_package(Threads REQUIRED)
+pkg_check_modules(JSON_C REQUIRED IMPORTED_TARGET json-c)
+
+set(DEFYX_DXCORE_LIB "" CACHE FILEPATH
+    "Path to the production or mock libdxcore_amd64.so")
+if(NOT DEFYX_DXCORE_LIB AND DEFINED ENV{DEFYX_DXCORE_LIB})
+  set(DEFYX_DXCORE_LIB "$ENV{DEFYX_DXCORE_LIB}")
+endif()
+
+set(DEFYX_CLI_VERSION "dev")
+file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/../../pubspec.yaml"
+     _pubspec_version_line REGEX "^version:[ \t]*" LIMIT_COUNT 1)
+if(_pubspec_version_line)
+  string(REGEX REPLACE "^version:[ \t]*([^+ \t]+).*$" "\\1"
+         DEFYX_CLI_VERSION "${_pubspec_version_line}")
+endif()
+
+function(defyx_cli_compile_settings target)
+  target_compile_features(${target} PUBLIC cxx_std_17)
+  target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+  target_compile_definitions(
+    ${target} PRIVATE DEFYX_CLI_VERSION="${DEFYX_CLI_VERSION}")
+endfunction()
+
+add_library(defyx_cli_support STATIC
+  src/cli_options.cpp
+  src/flowline.cpp
+  src/progress.cpp
+  src/status_file.cpp
+  src/tcp_forwarder.cpp
+)
+defyx_cli_compile_settings(defyx_cli_support)
+target_include_directories(defyx_cli_support PUBLIC "${CMAKE_CURRENT_LIST_DIR}/src")
+target_link_libraries(defyx_cli_support PUBLIC PkgConfig::JSON_C Threads::Threads)
+
+add_library(defyx_native_core STATIC
+  "${CMAKE_CURRENT_LIST_DIR}/../runner/defyx_core.cpp"
+)
+defyx_cli_compile_settings(defyx_native_core)
+target_include_directories(
+  defyx_native_core PUBLIC "${CMAKE_CURRENT_LIST_DIR}/../runner")
+target_link_libraries(
+  defyx_native_core PUBLIC ${CMAKE_DL_LIBS} Threads::Threads)
+
+add_executable(defyxvpn-cli src/main.cpp)
+defyx_cli_compile_settings(defyxvpn-cli)
+target_link_libraries(
+  defyxvpn-cli PRIVATE defyx_cli_support defyx_native_core)
+set_target_properties(
+  defyxvpn-cli PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+
+if(DEFYX_DXCORE_LIB)
+  get_filename_component(_dxcore_library "${DEFYX_DXCORE_LIB}" ABSOLUTE)
+  if(NOT EXISTS "${_dxcore_library}")
+    message(FATAL_ERROR "DEFYX_DXCORE_LIB does not exist: ${_dxcore_library}")
+  endif()
+
+  add_custom_command(
+    TARGET defyxvpn-cli POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${_dxcore_library}"
+            "$<TARGET_FILE_DIR:defyxvpn-cli>/libdxcore_amd64.so"
+    COMMENT "Copying DXcore beside defyxvpn-cli"
+  )
+  install(FILES "${_dxcore_library}"
+          DESTINATION "${CMAKE_INSTALL_BINDIR}"
+          RENAME "libdxcore_amd64.so")
+endif()
+
+install(TARGETS defyxvpn-cli RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+install(FILES README.md defyxvpn-cli.env.example
+        DESTINATION "${CMAKE_INSTALL_DOCDIR}")
+install(FILES defyxvpn-cli.service
+        DESTINATION "${CMAKE_INSTALL_DOCDIR}/systemd")
+
+if(BUILD_TESTING)
+  add_executable(defyxvpn-cli-tests tests/cli_tests.cpp)
+  defyx_cli_compile_settings(defyxvpn-cli-tests)
+  target_link_libraries(defyxvpn-cli-tests PRIVATE defyx_cli_support)
+  add_test(NAME defyxvpn-cli-tests COMMAND defyxvpn-cli-tests)
+  set_tests_properties(defyxvpn-cli-tests PROPERTIES TIMEOUT 15)
+
+  add_library(dxcore_mock SHARED tests/mock_dxcore.c)
+  set_target_properties(
+    dxcore_mock PROPERTIES
+    OUTPUT_NAME "dxcore_amd64"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test"
+  )
+  add_test(
+    NAME defyxvpn-cli-integration
+    COMMAND bash
+            "${CMAKE_CURRENT_LIST_DIR}/tests/integration_test.sh"
+            "$<TARGET_FILE:defyxvpn-cli>"
+            "$<TARGET_FILE:dxcore_mock>"
+  )
+  set_tests_properties(defyxvpn-cli-integration PROPERTIES TIMEOUT 15)
+endif()

--- a/linux/cli/README.md
+++ b/linux/cli/README.md
@@ -62,7 +62,8 @@ Requirements:
 
 Prebuilt release archives only require the json-c runtime library
 (`libjson-c5` on current Debian and Ubuntu releases); they do not require a
-compiler, CMake, Flutter, or GTK.
+compiler, CMake, Flutter, or GTK. The optional `--health-check` mode also
+requires the `curl` command.
 
 On Debian or Ubuntu:
 
@@ -116,6 +117,41 @@ time.
 
 Run `defyxvpn-cli --help` for every option and its environment-variable
 equivalent.
+
+### Connection health checks
+
+DXcore can report a method as connected even when that route cannot complete
+normal HTTPS transfers. With `--health-check`, the CLI starts the
+comma-separated connection methods one at a time and validates each method
+through DXcore's SOCKS5 endpoint. It reports the public proxy as connected
+only after the validation transfer completes:
+
+```bash
+./defyxvpn-cli connect \
+  --pattern "Hive,Xray,Outline,Masque" \
+  --health-check
+```
+
+The default probe downloads exactly 64 KiB over HTTPS from
+`https://speed.cloudflare.com/__down?bytes=65536`. A truncated response,
+TLS failure, non-2xx status, timeout, or smaller download rejects that method
+and advances to the next label. This is a startup validation; DXcore's own
+runtime health monitor remains enabled after a method passes.
+
+Networks that cannot reach the default endpoint can use another deterministic
+HTTPS response:
+
+```bash
+./defyxvpn-cli connect \
+  --health-check \
+  --health-check-url https://example.net/health.bin \
+  --health-check-min-bytes 65536 \
+  --health-check-timeout 30
+```
+
+The probe runs `curl` directly without a shell, forces remote DNS through the
+SOCKS5 proxy, follows HTTPS redirects only, and uses the operating system's
+normal CA certificate store.
 
 ## systemd
 

--- a/linux/cli/README.md
+++ b/linux/cli/README.md
@@ -1,0 +1,151 @@
+# DefyxVPN CLI
+
+`defyxvpn-cli` is a headless Linux client for DefyxVPN. It calls the same
+DXcore shared library as the Flutter desktop application, but it does not link
+Flutter, GTK, AppIndicator, Firebase, or any display-server libraries.
+
+The client stays in the foreground, which makes it suitable for SSH sessions,
+containers, and service managers such as systemd. `SIGINT` and `SIGTERM`
+gracefully stop DXcore before the process exits.
+
+## Current networking mode
+
+The Linux DXcore integration exposes a SOCKS5 proxy at `127.0.0.1:5000`.
+This matches the existing Linux desktop client and is the CLI default. The CLI
+does not create a TUN interface or silently edit system-wide proxy settings.
+
+Applications must use the proxy explicitly:
+
+```bash
+curl --proxy socks5h://127.0.0.1:5000 https://ifconfig.me
+```
+
+For a shell or service whose software honors proxy environment variables:
+
+```bash
+export ALL_PROXY=socks5h://127.0.0.1:5000
+export all_proxy="$ALL_PROXY"
+```
+
+### Listening on another address or port
+
+DXcore's own endpoint is fixed, so the CLI includes a TCP relay for exposing
+it on a different local address or port:
+
+```bash
+./defyxvpn-cli connect --listen-address 0.0.0.0 --listen-port 1080
+```
+
+Clients on another machine then use the server's real address, for example
+`socks5h://192.168.1.138:1080`, rather than the wildcard address
+`0.0.0.0`.
+
+The SOCKS5 endpoint does not provide user authentication. Binding to
+`0.0.0.0`, `::`, or another non-loopback address can expose the proxy to the
+network. Restrict the port to trusted source addresses with the host or
+network firewall.
+
+`0.0.0.0:5000` is not available because it overlaps DXcore's internal
+`127.0.0.1:5000` listener. Use another port with a wildcard address. A
+specific non-loopback IP, such as `192.168.1.138:5000`, does not overlap and
+can use port `5000`.
+
+## Build
+
+Requirements:
+
+- Linux and a C++17 compiler
+- CMake 3.13 or newer
+- `pkg-config`
+- json-c development headers
+- An x86_64 DXcore shared library named `libdxcore_amd64.so`
+
+Prebuilt release archives only require the json-c runtime library
+(`libjson-c5` on current Debian and Ubuntu releases); they do not require a
+compiler, CMake, Flutter, or GTK.
+
+On Debian or Ubuntu:
+
+```bash
+sudo apt-get install build-essential cmake ninja-build pkg-config libjson-c-dev
+cmake -S linux/cli -B build/linux-cli -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DDEFYX_DXCORE_LIB=/path/to/libdxcore_amd64.so
+cmake --build build/linux-cli
+ctest --test-dir build/linux-cli --output-on-failure
+```
+
+The binary and DXcore library are written to `build/linux-cli/bin/`. The
+production DefyxVPN release workflow supplies the private production DXcore
+binary. Contributors can still build and run all CLI unit tests without it by
+omitting `DEFYX_DXCORE_LIB`.
+
+## Usage
+
+Start a connection in the foreground:
+
+```bash
+./defyxvpn-cli connect
+```
+
+By default, the CLI requests the online flowline from DXcore and falls back to
+its cached copy. When `--pattern` is omitted, it uses the enabled flowline
+labels in their published order, matching the desktop client. It can also
+consume a signed offline export, a complete flowline API response, or a raw
+`flowLine` object:
+
+```bash
+./defyxvpn-cli connect \
+  --flowline-file /etc/defyxvpn/flowline.json \
+  --pattern "Warp,Psiphon" \
+  --listen-address 127.0.0.1 \
+  --listen-port 5000 \
+  --health-check
+```
+
+Inspect or stop a process from another terminal:
+
+```bash
+./defyxvpn-cli status
+./defyxvpn-cli disconnect
+```
+
+When using a non-default cache directory, pass the same `--cache-dir` to all
+three commands. Only one connection process can use a cache directory at a
+time.
+
+Run `defyxvpn-cli --help` for every option and its environment-variable
+equivalent.
+
+## systemd
+
+The files `defyxvpn-cli.service` and `defyxvpn-cli.env.example` provide a
+starting point for a system service. A minimal installation looks like:
+
+```bash
+sudo useradd --system --home /var/lib/defyxvpn --create-home defyxvpn
+sudo install -d -m 0755 /opt/defyxvpn /etc/defyxvpn
+sudo install -m 0755 defyxvpn-cli /opt/defyxvpn/
+sudo install -m 0644 libdxcore_amd64.so /opt/defyxvpn/
+sudo install -m 0600 defyxvpn-cli.env.example /etc/defyxvpn/defyxvpn.env
+sudo install -m 0644 defyxvpn-cli.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now defyxvpn-cli
+```
+
+Follow connection progress with:
+
+```bash
+sudo journalctl -u defyxvpn-cli -f
+```
+
+Keep offline flowline files and `/etc/defyxvpn/defyxvpn.env` readable only by
+the service administrator and service account.
+
+## Exit codes
+
+- `0`: command completed or the foreground connection shut down cleanly
+- `1`: invalid command-line arguments
+- `2`: configuration, file, lock, or DXcore startup error
+- `3`: no running CLI instance
+- `4`: connection failure or timeout

--- a/linux/cli/README.md
+++ b/linux/cli/README.md
@@ -135,8 +135,13 @@ only after the validation transfer completes:
 The default probe downloads exactly 64 KiB over HTTPS from
 `https://speed.cloudflare.com/__down?bytes=65536`. A truncated response,
 TLS failure, non-2xx status, timeout, or smaller download rejects that method
-and advances to the next label. This is a startup validation; DXcore's own
-runtime health monitor remains enabled after a method passes.
+and advances to the next label.
+
+After a method passes startup validation, the CLI repeats the same end-to-end
+probe every 60 seconds. Two consecutive failures mark the method unhealthy and
+advance to the next label. A successful probe resets the failure counter. If no
+methods remain, the CLI exits with code `4`; the provided systemd unit then
+restarts it after five seconds and begins again with the first method.
 
 Networks that cannot reach the default endpoint can use another deterministic
 HTTPS response:
@@ -146,12 +151,16 @@ HTTPS response:
   --health-check \
   --health-check-url https://example.net/health.bin \
   --health-check-min-bytes 65536 \
-  --health-check-timeout 30
+  --health-check-timeout 30 \
+  --health-check-interval 60 \
+  --health-check-failures 2
 ```
 
 The probe runs `curl` directly without a shell, forces remote DNS through the
 SOCKS5 proxy, follows HTTPS redirects only, and uses the operating system's
-normal CA certificate store.
+normal CA certificate store. Set `--health-check-interval 0` to keep startup
+method validation but disable the CLI's periodic checks. DXcore's own internal
+health monitor remains enabled independently.
 
 ## systemd
 

--- a/linux/cli/defyxvpn-cli.env.example
+++ b/linux/cli/defyxvpn-cli.env.example
@@ -15,6 +15,11 @@ DEFYX_LISTEN_PORT=5000
 
 DEFYX_DEEP_SCAN=false
 DEFYX_HEALTH_CHECK=false
+# The startup health check requires curl. It tries comma-separated methods in
+# order and accepts a method only after this HTTPS transfer completes.
+DEFYX_HEALTH_CHECK_URL=https://speed.cloudflare.com/__down?bytes=65536
+DEFYX_HEALTH_CHECK_MIN_BYTES=65536
+DEFYX_HEALTH_CHECK_TIMEOUT=20
 DEFYX_CACHED_FLOWLINE=false
 DEFYX_TEST_FLOWLINE=false
 DEFYX_CONNECT_TIMEOUT=0

--- a/linux/cli/defyxvpn-cli.env.example
+++ b/linux/cli/defyxvpn-cli.env.example
@@ -1,0 +1,22 @@
+# Optional: the release archive places DXcore beside the CLI, so this is
+# normally discovered automatically.
+# DEFYX_CORE_LIB=/opt/defyxvpn/libdxcore_amd64.so
+
+# Optional signed offline flowline exported by DefyxVPN.
+# DEFYX_FLOWLINE_FILE=/etc/defyxvpn/flowline.json
+
+# Comma-separated labels. Empty derives the enabled labels from the flowline.
+DEFYX_PATTERN=
+
+# DXcore itself uses 127.0.0.1:5000. A different endpoint is exposed through
+# the CLI's built-in TCP relay.
+DEFYX_LISTEN_ADDRESS=127.0.0.1
+DEFYX_LISTEN_PORT=5000
+
+DEFYX_DEEP_SCAN=false
+DEFYX_HEALTH_CHECK=false
+DEFYX_CACHED_FLOWLINE=false
+DEFYX_TEST_FLOWLINE=false
+DEFYX_CONNECT_TIMEOUT=0
+DEFYX_VERBOSE=false
+DEFYX_QUIET=false

--- a/linux/cli/defyxvpn-cli.env.example
+++ b/linux/cli/defyxvpn-cli.env.example
@@ -15,11 +15,13 @@ DEFYX_LISTEN_PORT=5000
 
 DEFYX_DEEP_SCAN=false
 DEFYX_HEALTH_CHECK=false
-# The startup health check requires curl. It tries comma-separated methods in
-# order and accepts a method only after this HTTPS transfer completes.
+# Health checks require curl. Startup validation tries comma-separated methods
+# in order. Runtime checks fail over after the configured consecutive failures.
 DEFYX_HEALTH_CHECK_URL=https://speed.cloudflare.com/__down?bytes=65536
 DEFYX_HEALTH_CHECK_MIN_BYTES=65536
 DEFYX_HEALTH_CHECK_TIMEOUT=20
+DEFYX_HEALTH_CHECK_INTERVAL=60
+DEFYX_HEALTH_CHECK_FAILURES=2
 DEFYX_CACHED_FLOWLINE=false
 DEFYX_TEST_FLOWLINE=false
 DEFYX_CONNECT_TIMEOUT=0

--- a/linux/cli/defyxvpn-cli.service
+++ b/linux/cli/defyxvpn-cli.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=DefyxVPN headless client
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/defyxvpn/defyxvpn.env
+ExecStart=/opt/defyxvpn/defyxvpn-cli connect --cache-dir /var/lib/defyxvpn
+Restart=on-failure
+RestartSec=5
+User=defyxvpn
+Group=defyxvpn
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/defyxvpn
+
+[Install]
+WantedBy=multi-user.target

--- a/linux/cli/src/cli_options.cpp
+++ b/linux/cli/src/cli_options.cpp
@@ -135,6 +135,21 @@ Options OptionsFromEnvironment() {
        options.health_check_timeout_seconds == 0)) {
     options.health_check_timeout_seconds = 0;
   }
+  const std::string health_check_interval =
+      GetEnvironment("DEFYX_HEALTH_CHECK_INTERVAL");
+  if (!health_check_interval.empty() &&
+      !ParseNonNegativeInteger(health_check_interval,
+                               &options.health_check_interval_seconds)) {
+    options.health_check_interval_seconds = -1;
+  }
+  const std::string health_check_failures =
+      GetEnvironment("DEFYX_HEALTH_CHECK_FAILURES");
+  if (!health_check_failures.empty() &&
+      (!ParseNonNegativeInteger(health_check_failures,
+                                &options.health_check_failures) ||
+       options.health_check_failures == 0)) {
+    options.health_check_failures = 0;
+  }
   options.cached_flowline = ParseBoolean(
       GetEnvironment("DEFYX_CACHED_FLOWLINE"), options.cached_flowline);
   options.test_flowline =
@@ -267,6 +282,33 @@ ParseResult ParseOptions(const std::vector<std::string>& arguments,
       }
       continue;
     }
+    if (argument == "--health-check-interval") {
+      std::string value;
+      if (!ReadValue(arguments, &index, argument, &value, &result.error)) {
+        return result;
+      }
+      if (!ParseNonNegativeInteger(
+              value, &result.options.health_check_interval_seconds)) {
+        result.error =
+            "--health-check-interval must be a non-negative number of seconds";
+        return result;
+      }
+      continue;
+    }
+    if (argument == "--health-check-failures") {
+      std::string value;
+      if (!ReadValue(arguments, &index, argument, &value, &result.error)) {
+        return result;
+      }
+      if (!ParseNonNegativeInteger(
+              value, &result.options.health_check_failures) ||
+          result.options.health_check_failures == 0) {
+        result.error =
+            "--health-check-failures must be a positive number";
+        return result;
+      }
+      continue;
+    }
     if (argument == "--cached-flowline") {
       result.options.cached_flowline = true;
       continue;
@@ -333,6 +375,14 @@ ParseResult ParseOptions(const std::vector<std::string>& arguments,
     result.error =
         "--health-check-timeout must be a positive number of seconds";
   }
+  if (result.options.health_check_interval_seconds < 0) {
+    result.error =
+        "--health-check-interval must be a non-negative number of seconds";
+  }
+  if (result.options.health_check_failures <= 0) {
+    result.error =
+        "--health-check-failures must be a positive number";
+  }
   return result;
 }
 
@@ -361,6 +411,10 @@ Connect options:
                          Minimum complete response size (default: 65536)
   --health-check-timeout SECONDS
                          Per-check timeout (default: 20)
+  --health-check-interval SECONDS
+                         Runtime check interval; 0 disables it (default: 60)
+  --health-check-failures N
+                         Consecutive failures before failover (default: 2)
   --timeout SECONDS      Stop if not connected in time (0 means no timeout)
   --verbose              Enable verbose DXcore logging
   --quiet                Only print state changes and errors
@@ -371,7 +425,8 @@ The same settings can be supplied with DEFYX_CORE_LIB, DEFYX_CACHE_DIR,
 DEFYX_FLOWLINE_FILE, DEFYX_PATTERN, DEFYX_CACHED_FLOWLINE,
 DEFYX_TEST_FLOWLINE, DEFYX_DEEP_SCAN, DEFYX_HEALTH_CHECK,
 DEFYX_HEALTH_CHECK_URL, DEFYX_HEALTH_CHECK_MIN_BYTES,
-DEFYX_HEALTH_CHECK_TIMEOUT,
+DEFYX_HEALTH_CHECK_TIMEOUT, DEFYX_HEALTH_CHECK_INTERVAL,
+DEFYX_HEALTH_CHECK_FAILURES,
 DEFYX_LISTEN_ADDRESS, DEFYX_LISTEN_PORT, DEFYX_CONNECT_TIMEOUT,
 DEFYX_VERBOSE, and DEFYX_QUIET.
 )";

--- a/linux/cli/src/cli_options.cpp
+++ b/linux/cli/src/cli_options.cpp
@@ -1,0 +1,304 @@
+#include "cli_options.h"
+#include "tcp_forwarder.h"
+
+#include <cerrno>
+#include <climits>
+#include <cstdlib>
+#include <sstream>
+#include <string>
+
+#include <unistd.h>
+
+namespace defyx_cli {
+
+namespace {
+
+std::string GetEnvironment(const char* name) {
+  const char* value = std::getenv(name);
+  return value == nullptr ? std::string() : std::string(value);
+}
+
+bool ParseBoolean(const std::string& value, bool fallback) {
+  if (value == "1" || value == "true" || value == "yes" || value == "on") {
+    return true;
+  }
+  if (value == "0" || value == "false" || value == "no" || value == "off") {
+    return false;
+  }
+  return fallback;
+}
+
+bool ParseNonNegativeInteger(const std::string& value, int* result) {
+  if (value.empty() || result == nullptr) {
+    return false;
+  }
+
+  char* end = nullptr;
+  errno = 0;
+  const long parsed = std::strtol(value.c_str(), &end, 10);
+  if (errno != 0 || end == value.c_str() || *end != '\0' || parsed < 0 ||
+      parsed > INT_MAX) {
+    return false;
+  }
+
+  *result = static_cast<int>(parsed);
+  return true;
+}
+
+bool ParsePort(const std::string& value, int* result) {
+  int parsed = 0;
+  if (!ParseNonNegativeInteger(value, &parsed) || parsed == 0 ||
+      parsed > 65535) {
+    return false;
+  }
+  *result = parsed;
+  return true;
+}
+
+std::string DefaultCacheDirectory() {
+  std::string cache_home = GetEnvironment("XDG_CACHE_HOME");
+  if (!cache_home.empty()) {
+    return cache_home + "/defyxvpn";
+  }
+
+  std::string home = GetEnvironment("HOME");
+  if (!home.empty()) {
+    return home + "/.cache/defyxvpn";
+  }
+
+  return "/tmp/defyxvpn-" + std::to_string(static_cast<long long>(getuid()));
+}
+
+bool ReadValue(const std::vector<std::string>& arguments, size_t* index,
+               const std::string& option, std::string* value,
+               std::string* error) {
+  if (*index + 1 >= arguments.size()) {
+    *error = option + " requires a value";
+    return false;
+  }
+  *value = arguments[++(*index)];
+  if (value->empty()) {
+    *error = option + " requires a non-empty value";
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+Options OptionsFromEnvironment() {
+  Options options;
+  options.core_library = GetEnvironment("DEFYX_CORE_LIB");
+  options.flowline_file = GetEnvironment("DEFYX_FLOWLINE_FILE");
+  options.pattern = GetEnvironment("DEFYX_PATTERN");
+
+  const std::string listen_address = GetEnvironment("DEFYX_LISTEN_ADDRESS");
+  if (!listen_address.empty()) {
+    options.listen_address = listen_address;
+  }
+  const std::string listen_port = GetEnvironment("DEFYX_LISTEN_PORT");
+  if (!listen_port.empty() &&
+      !ParsePort(listen_port, &options.listen_port)) {
+    options.listen_port = 0;
+  }
+
+  options.cache_directory = GetEnvironment("DEFYX_CACHE_DIR");
+  if (options.cache_directory.empty()) {
+    options.cache_directory = DefaultCacheDirectory();
+  }
+
+  options.deep_scan =
+      ParseBoolean(GetEnvironment("DEFYX_DEEP_SCAN"), options.deep_scan);
+  options.health_check =
+      ParseBoolean(GetEnvironment("DEFYX_HEALTH_CHECK"), options.health_check);
+  options.cached_flowline = ParseBoolean(
+      GetEnvironment("DEFYX_CACHED_FLOWLINE"), options.cached_flowline);
+  options.test_flowline =
+      ParseBoolean(GetEnvironment("DEFYX_TEST_FLOWLINE"), options.test_flowline);
+  options.verbose =
+      ParseBoolean(GetEnvironment("DEFYX_VERBOSE"), options.verbose);
+  options.quiet = ParseBoolean(GetEnvironment("DEFYX_QUIET"), options.quiet);
+
+  const std::string timeout = GetEnvironment("DEFYX_CONNECT_TIMEOUT");
+  if (!timeout.empty()) {
+    ParseNonNegativeInteger(timeout, &options.timeout_seconds);
+  }
+
+  return options;
+}
+
+ParseResult ParseOptions(const std::vector<std::string>& arguments,
+                         const Options& defaults) {
+  ParseResult result;
+  result.options = defaults;
+
+  bool command_set = false;
+  for (size_t index = 0; index < arguments.size(); ++index) {
+    const std::string& argument = arguments[index];
+
+    if (argument == "-h" || argument == "--help") {
+      result.options.command = Command::help;
+      return result;
+    }
+    if (argument == "-v" || argument == "--version") {
+      result.options.command = Command::version;
+      return result;
+    }
+    if (argument == "--core-lib") {
+      if (!ReadValue(arguments, &index, argument,
+                     &result.options.core_library, &result.error)) {
+        return result;
+      }
+      continue;
+    }
+    if (argument == "--cache-dir") {
+      if (!ReadValue(arguments, &index, argument,
+                     &result.options.cache_directory, &result.error)) {
+        return result;
+      }
+      continue;
+    }
+    if (argument == "--flowline-file") {
+      if (!ReadValue(arguments, &index, argument,
+                     &result.options.flowline_file, &result.error)) {
+        return result;
+      }
+      continue;
+    }
+    if (argument == "--pattern") {
+      if (!ReadValue(arguments, &index, argument, &result.options.pattern,
+                     &result.error)) {
+        return result;
+      }
+      continue;
+    }
+    if (argument == "--listen-address" || argument == "--listen-ip") {
+      if (!ReadValue(arguments, &index, argument,
+                     &result.options.listen_address, &result.error)) {
+        return result;
+      }
+      continue;
+    }
+    if (argument == "--listen-port") {
+      std::string value;
+      if (!ReadValue(arguments, &index, argument, &value, &result.error)) {
+        return result;
+      }
+      if (!ParsePort(value, &result.options.listen_port)) {
+        result.error = "--listen-port must be a number from 1 to 65535";
+        return result;
+      }
+      continue;
+    }
+    if (argument == "--timeout") {
+      std::string value;
+      if (!ReadValue(arguments, &index, argument, &value, &result.error)) {
+        return result;
+      }
+      if (!ParseNonNegativeInteger(value, &result.options.timeout_seconds)) {
+        result.error = "--timeout must be a non-negative number of seconds";
+        return result;
+      }
+      continue;
+    }
+    if (argument == "--deep-scan") {
+      result.options.deep_scan = true;
+      continue;
+    }
+    if (argument == "--health-check") {
+      result.options.health_check = true;
+      continue;
+    }
+    if (argument == "--cached-flowline") {
+      result.options.cached_flowline = true;
+      continue;
+    }
+    if (argument == "--test-flowline") {
+      result.options.test_flowline = true;
+      continue;
+    }
+    if (argument == "--verbose") {
+      result.options.verbose = true;
+      continue;
+    }
+    if (argument == "--quiet") {
+      result.options.quiet = true;
+      continue;
+    }
+
+    if (!argument.empty() && argument.front() == '-') {
+      result.error = "unknown option: " + argument;
+      return result;
+    }
+    if (command_set) {
+      result.error = "unexpected argument: " + argument;
+      return result;
+    }
+
+    command_set = true;
+    if (argument == "connect" || argument == "start") {
+      result.options.command = Command::connect;
+    } else if (argument == "status") {
+      result.options.command = Command::status;
+    } else if (argument == "disconnect" || argument == "stop") {
+      result.options.command = Command::disconnect;
+    } else if (argument == "help") {
+      result.options.command = Command::help;
+    } else if (argument == "version") {
+      result.options.command = Command::version;
+    } else {
+      result.error = "unknown command: " + argument;
+      return result;
+    }
+  }
+
+  if (!command_set) {
+    result.options.command = Command::help;
+  }
+  if (!IsIpAddress(result.options.listen_address)) {
+    result.error =
+        "--listen-address must be a literal IPv4 or IPv6 address";
+    return result;
+  }
+  if (result.options.listen_port <= 0 ||
+      result.options.listen_port > 65535) {
+    result.error = "--listen-port must be a number from 1 to 65535";
+  }
+  return result;
+}
+
+std::string Usage() {
+  return R"(DefyxVPN headless client
+
+Usage:
+  defyxvpn-cli connect [options]
+  defyxvpn-cli status [--cache-dir PATH]
+  defyxvpn-cli disconnect [--cache-dir PATH]
+  defyxvpn-cli version
+
+Connect options:
+  --core-lib PATH        Path to libdxcore_amd64.so
+  --cache-dir PATH       Runtime/cache directory
+  --flowline-file PATH   Signed flowline export, full response, or raw config
+  --pattern LABELS       Comma-separated connection method labels
+  --listen-address IP    SOCKS5 listen IP (default: 127.0.0.1)
+  --listen-port PORT      SOCKS5 listen port (default: 5000)
+  --cached-flowline      Use DXcore's cached flowline
+  --test-flowline        Request the test flowline
+  --deep-scan            Keep scanning connection methods
+  --health-check         Enable DXcore health checks
+  --timeout SECONDS      Stop if not connected in time (0 means no timeout)
+  --verbose              Enable verbose DXcore logging
+  --quiet                Only print state changes and errors
+  -h, --help             Show this help
+  -v, --version          Show the version
+
+The same settings can be supplied with DEFYX_CORE_LIB, DEFYX_CACHE_DIR,
+DEFYX_FLOWLINE_FILE, DEFYX_PATTERN, DEFYX_CACHED_FLOWLINE,
+DEFYX_TEST_FLOWLINE, DEFYX_DEEP_SCAN, DEFYX_HEALTH_CHECK,
+DEFYX_LISTEN_ADDRESS, DEFYX_LISTEN_PORT, DEFYX_CONNECT_TIMEOUT,
+DEFYX_VERBOSE, and DEFYX_QUIET.
+)";
+}
+
+}  // namespace defyx_cli

--- a/linux/cli/src/cli_options.cpp
+++ b/linux/cli/src/cli_options.cpp
@@ -55,6 +55,10 @@ bool ParsePort(const std::string& value, int* result) {
   return true;
 }
 
+bool IsHttpsUrl(const std::string& value) {
+  return value.size() > 8 && value.compare(0, 8, "https://") == 0;
+}
+
 std::string DefaultCacheDirectory() {
   std::string cache_home = GetEnvironment("XDG_CACHE_HOME");
   if (!cache_home.empty()) {
@@ -111,6 +115,26 @@ Options OptionsFromEnvironment() {
       ParseBoolean(GetEnvironment("DEFYX_DEEP_SCAN"), options.deep_scan);
   options.health_check =
       ParseBoolean(GetEnvironment("DEFYX_HEALTH_CHECK"), options.health_check);
+  const std::string health_check_url =
+      GetEnvironment("DEFYX_HEALTH_CHECK_URL");
+  if (!health_check_url.empty()) {
+    options.health_check_url = health_check_url;
+  }
+  const std::string health_check_min_bytes =
+      GetEnvironment("DEFYX_HEALTH_CHECK_MIN_BYTES");
+  if (!health_check_min_bytes.empty() &&
+      !ParseNonNegativeInteger(health_check_min_bytes,
+                               &options.health_check_min_bytes)) {
+    options.health_check_min_bytes = -1;
+  }
+  const std::string health_check_timeout =
+      GetEnvironment("DEFYX_HEALTH_CHECK_TIMEOUT");
+  if (!health_check_timeout.empty() &&
+      (!ParseNonNegativeInteger(health_check_timeout,
+                                &options.health_check_timeout_seconds) ||
+       options.health_check_timeout_seconds == 0)) {
+    options.health_check_timeout_seconds = 0;
+  }
   options.cached_flowline = ParseBoolean(
       GetEnvironment("DEFYX_CACHED_FLOWLINE"), options.cached_flowline);
   options.test_flowline =
@@ -209,6 +233,40 @@ ParseResult ParseOptions(const std::vector<std::string>& arguments,
       result.options.health_check = true;
       continue;
     }
+    if (argument == "--health-check-url") {
+      if (!ReadValue(arguments, &index, argument,
+                     &result.options.health_check_url, &result.error)) {
+        return result;
+      }
+      continue;
+    }
+    if (argument == "--health-check-min-bytes") {
+      std::string value;
+      if (!ReadValue(arguments, &index, argument, &value, &result.error)) {
+        return result;
+      }
+      if (!ParseNonNegativeInteger(
+              value, &result.options.health_check_min_bytes)) {
+        result.error =
+            "--health-check-min-bytes must be a non-negative number";
+        return result;
+      }
+      continue;
+    }
+    if (argument == "--health-check-timeout") {
+      std::string value;
+      if (!ReadValue(arguments, &index, argument, &value, &result.error)) {
+        return result;
+      }
+      if (!ParseNonNegativeInteger(
+              value, &result.options.health_check_timeout_seconds) ||
+          result.options.health_check_timeout_seconds == 0) {
+        result.error =
+            "--health-check-timeout must be a positive number of seconds";
+        return result;
+      }
+      continue;
+    }
     if (argument == "--cached-flowline") {
       result.options.cached_flowline = true;
       continue;
@@ -264,6 +322,17 @@ ParseResult ParseOptions(const std::vector<std::string>& arguments,
       result.options.listen_port > 65535) {
     result.error = "--listen-port must be a number from 1 to 65535";
   }
+  if (!IsHttpsUrl(result.options.health_check_url)) {
+    result.error = "--health-check-url must use https://";
+  }
+  if (result.options.health_check_min_bytes < 0) {
+    result.error =
+        "--health-check-min-bytes must be a non-negative number";
+  }
+  if (result.options.health_check_timeout_seconds <= 0) {
+    result.error =
+        "--health-check-timeout must be a positive number of seconds";
+  }
   return result;
 }
 
@@ -286,7 +355,12 @@ Connect options:
   --cached-flowline      Use DXcore's cached flowline
   --test-flowline        Request the test flowline
   --deep-scan            Keep scanning connection methods
-  --health-check         Enable DXcore health checks
+  --health-check         Verify HTTPS and try each method until one passes
+  --health-check-url URL HTTPS endpoint used for validation
+  --health-check-min-bytes N
+                         Minimum complete response size (default: 65536)
+  --health-check-timeout SECONDS
+                         Per-check timeout (default: 20)
   --timeout SECONDS      Stop if not connected in time (0 means no timeout)
   --verbose              Enable verbose DXcore logging
   --quiet                Only print state changes and errors
@@ -296,6 +370,8 @@ Connect options:
 The same settings can be supplied with DEFYX_CORE_LIB, DEFYX_CACHE_DIR,
 DEFYX_FLOWLINE_FILE, DEFYX_PATTERN, DEFYX_CACHED_FLOWLINE,
 DEFYX_TEST_FLOWLINE, DEFYX_DEEP_SCAN, DEFYX_HEALTH_CHECK,
+DEFYX_HEALTH_CHECK_URL, DEFYX_HEALTH_CHECK_MIN_BYTES,
+DEFYX_HEALTH_CHECK_TIMEOUT,
 DEFYX_LISTEN_ADDRESS, DEFYX_LISTEN_PORT, DEFYX_CONNECT_TIMEOUT,
 DEFYX_VERBOSE, and DEFYX_QUIET.
 )";

--- a/linux/cli/src/cli_options.h
+++ b/linux/cli/src/cli_options.h
@@ -27,6 +27,8 @@ struct Options {
       "https://speed.cloudflare.com/__down?bytes=65536";
   int health_check_min_bytes = 65536;
   int health_check_timeout_seconds = 20;
+  int health_check_interval_seconds = 60;
+  int health_check_failures = 2;
   bool cached_flowline = false;
   bool test_flowline = false;
   bool verbose = false;

--- a/linux/cli/src/cli_options.h
+++ b/linux/cli/src/cli_options.h
@@ -23,6 +23,10 @@ struct Options {
   int listen_port = 5000;
   bool deep_scan = false;
   bool health_check = false;
+  std::string health_check_url =
+      "https://speed.cloudflare.com/__down?bytes=65536";
+  int health_check_min_bytes = 65536;
+  int health_check_timeout_seconds = 20;
   bool cached_flowline = false;
   bool test_flowline = false;
   bool verbose = false;

--- a/linux/cli/src/cli_options.h
+++ b/linux/cli/src/cli_options.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace defyx_cli {
+
+enum class Command {
+  connect,
+  status,
+  disconnect,
+  help,
+  version,
+};
+
+struct Options {
+  Command command = Command::help;
+  std::string core_library;
+  std::string cache_directory;
+  std::string flowline_file;
+  std::string pattern;
+  std::string listen_address = "127.0.0.1";
+  int listen_port = 5000;
+  bool deep_scan = false;
+  bool health_check = false;
+  bool cached_flowline = false;
+  bool test_flowline = false;
+  bool verbose = false;
+  bool quiet = false;
+  int timeout_seconds = 0;
+};
+
+struct ParseResult {
+  Options options;
+  std::string error;
+
+  bool ok() const { return error.empty(); }
+};
+
+Options OptionsFromEnvironment();
+ParseResult ParseOptions(const std::vector<std::string>& arguments,
+                         const Options& defaults);
+std::string Usage();
+
+}  // namespace defyx_cli

--- a/linux/cli/src/flowline.cpp
+++ b/linux/cli/src/flowline.cpp
@@ -1,0 +1,138 @@
+#include "flowline.h"
+
+#include <json-c/json.h>
+
+#include <cctype>
+#include <memory>
+#include <string>
+
+namespace defyx_cli {
+
+namespace {
+
+using JsonPointer = std::unique_ptr<json_object, decltype(&json_object_put)>;
+using TokenerPointer =
+    std::unique_ptr<json_tokener, decltype(&json_tokener_free)>;
+
+std::string Trim(const std::string& input) {
+  size_t begin = 0;
+  while (begin < input.size() &&
+         std::isspace(static_cast<unsigned char>(input[begin])) != 0) {
+    ++begin;
+  }
+
+  size_t end = input.size();
+  while (end > begin &&
+         std::isspace(static_cast<unsigned char>(input[end - 1])) != 0) {
+    --end;
+  }
+  return input.substr(begin, end - begin);
+}
+
+std::string EnabledLabelPattern(json_object* flowline) {
+  json_object* configs = flowline;
+  if (json_object_get_type(configs) == json_type_object) {
+    json_object* nested = nullptr;
+    if (!json_object_object_get_ex(configs, "flowLine", &nested)) {
+      return {};
+    }
+    configs = nested;
+  }
+  if (json_object_get_type(configs) != json_type_array) {
+    return {};
+  }
+
+  std::string pattern;
+  const size_t count = json_object_array_length(configs);
+  for (size_t index = 0; index < count; ++index) {
+    json_object* config = json_object_array_get_idx(configs, index);
+    json_object* enabled = nullptr;
+    json_object* label = nullptr;
+    if (json_object_get_type(config) != json_type_object ||
+        !json_object_object_get_ex(config, "enabled", &enabled) ||
+        json_object_get_type(enabled) != json_type_boolean ||
+        json_object_get_boolean(enabled) == 0 ||
+        !json_object_object_get_ex(config, "label", &label) ||
+        json_object_get_type(label) != json_type_string) {
+      continue;
+    }
+
+    const char* label_value = json_object_get_string(label);
+    if (label_value == nullptr || label_value[0] == '\0') {
+      continue;
+    }
+    if (!pattern.empty()) {
+      pattern += ',';
+    }
+    pattern += label_value;
+  }
+  return pattern;
+}
+
+}  // namespace
+
+FlowLineResult NormalizeFlowLine(const std::string& payload) {
+  FlowLineResult result;
+  std::string normalized_input = Trim(payload);
+  if (normalized_input.size() >= 3 &&
+      static_cast<unsigned char>(normalized_input[0]) == 0xef &&
+      static_cast<unsigned char>(normalized_input[1]) == 0xbb &&
+      static_cast<unsigned char>(normalized_input[2]) == 0xbf) {
+    normalized_input.erase(0, 3);
+  }
+
+  if (normalized_input.empty()) {
+    result.error = "flowline is empty";
+    return result;
+  }
+
+  TokenerPointer tokener(json_tokener_new(), &json_tokener_free);
+  json_tokener_set_flags(tokener.get(), JSON_TOKENER_STRICT);
+  JsonPointer root(
+      json_tokener_parse_ex(tokener.get(), normalized_input.data(),
+                            static_cast<int>(normalized_input.size())),
+      &json_object_put);
+  const json_tokener_error parse_error =
+      json_tokener_get_error(tokener.get());
+  if (!root || parse_error != json_tokener_success) {
+    result.error =
+        std::string("flowline is not valid JSON: ") +
+        json_tokener_error_desc(parse_error);
+    return result;
+  }
+
+  json_object* selected = root.get();
+  const json_type root_type = json_object_get_type(root.get());
+  if (root_type == json_type_object) {
+    json_object* nested_flowline = nullptr;
+    json_object* start_line = nullptr;
+    const bool is_raw_flowline =
+        json_object_object_get_ex(root.get(), "startLine", &start_line);
+
+    if (!is_raw_flowline &&
+        json_object_object_get_ex(root.get(), "flowLine", &nested_flowline)) {
+      selected = nested_flowline;
+    } else if (!is_raw_flowline && nested_flowline == nullptr) {
+      result.error =
+          "flowline JSON must contain a top-level flowLine property";
+      return result;
+    }
+  } else if (root_type != json_type_array) {
+    result.error = "flowline JSON must be an object or array";
+    return result;
+  }
+
+  const json_type selected_type = json_object_get_type(selected);
+  if (selected_type != json_type_object &&
+      selected_type != json_type_array) {
+    result.error = "the flowLine value must be an object or array";
+    return result;
+  }
+
+  result.value =
+      json_object_to_json_string_ext(selected, JSON_C_TO_STRING_PLAIN);
+  result.default_pattern = EnabledLabelPattern(selected);
+  return result;
+}
+
+}  // namespace defyx_cli

--- a/linux/cli/src/flowline.h
+++ b/linux/cli/src/flowline.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+namespace defyx_cli {
+
+struct FlowLineResult {
+  std::string value;
+  std::string default_pattern;
+  std::string error;
+
+  bool ok() const { return error.empty(); }
+};
+
+// Converts either a full API response or a raw flowLine object/array into the
+// compact JSON payload expected by DXcore's StartVPN function.
+FlowLineResult NormalizeFlowLine(const std::string& payload);
+
+}  // namespace defyx_cli

--- a/linux/cli/src/health_check.cpp
+++ b/linux/cli/src/health_check.cpp
@@ -1,0 +1,233 @@
+#include "health_check.h"
+
+#include "tcp_forwarder.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <cctype>
+#include <cstring>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+extern char** environ;
+
+namespace defyx_cli {
+
+namespace {
+
+std::string Trim(const std::string& value) {
+  size_t first = 0;
+  while (first < value.size() &&
+         std::isspace(static_cast<unsigned char>(value[first]))) {
+    ++first;
+  }
+
+  size_t last = value.size();
+  while (last > first &&
+         std::isspace(static_cast<unsigned char>(value[last - 1]))) {
+    --last;
+  }
+  return value.substr(first, last - first);
+}
+
+bool ParseMetrics(const std::string& output, HealthCheckResult* result) {
+  std::istringstream stream(output);
+  unsigned long long downloaded_bytes = 0;
+  if (!(stream >> result->http_status >> downloaded_bytes)) {
+    return false;
+  }
+  result->downloaded_bytes =
+      static_cast<uint64_t>(downloaded_bytes);
+  return true;
+}
+
+}  // namespace
+
+std::vector<std::string> SplitConnectionMethods(
+    const std::string& pattern) {
+  std::vector<std::string> methods;
+  std::unordered_set<std::string> seen;
+  size_t start = 0;
+
+  while (start <= pattern.size()) {
+    const size_t separator = pattern.find(',', start);
+    const size_t length =
+        separator == std::string::npos ? std::string::npos
+                                       : separator - start;
+    std::string method = Trim(pattern.substr(start, length));
+    if (!method.empty() && seen.insert(method).second) {
+      methods.push_back(std::move(method));
+    }
+    if (separator == std::string::npos) {
+      break;
+    }
+    start = separator + 1;
+  }
+  return methods;
+}
+
+HealthCheckResult RunHttpsHealthCheck(
+    const HealthCheckSettings& settings) {
+  HealthCheckResult result;
+  int output_pipe[2] {-1, -1};
+  if (pipe(output_pipe) != 0) {
+    result.error =
+        "cannot create health-check output pipe: " +
+        std::string(std::strerror(errno));
+    return result;
+  }
+
+  posix_spawn_file_actions_t actions;
+  int action_result = posix_spawn_file_actions_init(&actions);
+  if (action_result != 0) {
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    result.error =
+        "cannot prepare health-check process: " +
+        std::string(std::strerror(action_result));
+    return result;
+  }
+  if (action_result == 0) {
+    action_result = posix_spawn_file_actions_adddup2(
+        &actions, output_pipe[1], STDOUT_FILENO);
+  }
+  if (action_result == 0) {
+    action_result =
+        posix_spawn_file_actions_addclose(&actions, output_pipe[0]);
+  }
+  if (action_result == 0) {
+    action_result =
+        posix_spawn_file_actions_addclose(&actions, output_pipe[1]);
+  }
+  if (action_result != 0) {
+    posix_spawn_file_actions_destroy(&actions);
+    close(output_pipe[0]);
+    close(output_pipe[1]);
+    result.error =
+        "cannot prepare health-check process: " +
+        std::string(std::strerror(action_result));
+    return result;
+  }
+
+  const int connect_timeout =
+      std::max(1, std::min(10, settings.timeout_seconds));
+  std::vector<std::string> arguments {
+      settings.curl_executable,
+      "--disable",
+      "--silent",
+      "--show-error",
+      "--location",
+      "--fail",
+      "--proto",
+      "=https",
+      "--proto-redir",
+      "=https",
+      "--connect-timeout",
+      std::to_string(connect_timeout),
+      "--max-time",
+      std::to_string(settings.timeout_seconds),
+      "--proxy",
+      FormatSocksEndpoint(settings.proxy_address, settings.proxy_port),
+      "--noproxy",
+      "",
+      "--output",
+      "/dev/null",
+      "--write-out",
+      "%{http_code} %{size_download}\n",
+      settings.url,
+  };
+  std::vector<char*> argv;
+  argv.reserve(arguments.size() + 1);
+  for (std::string& argument : arguments) {
+    argv.push_back(argument.data());
+  }
+  argv.push_back(nullptr);
+
+  pid_t child = -1;
+  const int spawn_result =
+      posix_spawnp(&child, settings.curl_executable.c_str(), &actions,
+                   nullptr, argv.data(), environ);
+  posix_spawn_file_actions_destroy(&actions);
+  close(output_pipe[1]);
+
+  if (spawn_result != 0) {
+    close(output_pipe[0]);
+    result.error =
+        "cannot start curl for health check: " +
+        std::string(std::strerror(spawn_result));
+    return result;
+  }
+
+  std::string output;
+  char buffer[256];
+  while (output.size() < 4096) {
+    const ssize_t count = read(output_pipe[0], buffer, sizeof(buffer));
+    if (count > 0) {
+      output.append(buffer, static_cast<size_t>(count));
+      continue;
+    }
+    if (count < 0 && errno == EINTR) {
+      continue;
+    }
+    break;
+  }
+  close(output_pipe[0]);
+
+  int child_status = 0;
+  while (waitpid(child, &child_status, 0) < 0) {
+    if (errno == EINTR) {
+      continue;
+    }
+    result.error =
+        "cannot wait for curl health check: " +
+        std::string(std::strerror(errno));
+    return result;
+  }
+
+  const bool metrics_valid = ParseMetrics(output, &result);
+  if (WIFEXITED(child_status)) {
+    result.exit_code = WEXITSTATUS(child_status);
+    if (result.exit_code != 0) {
+      result.error =
+          "curl exited with code " + std::to_string(result.exit_code);
+      return result;
+    }
+  } else if (WIFSIGNALED(child_status)) {
+    result.error =
+        "curl was terminated by signal " +
+        std::to_string(WTERMSIG(child_status));
+    return result;
+  } else {
+    result.error = "curl did not exit normally";
+    return result;
+  }
+
+  if (!metrics_valid) {
+    result.error = "curl returned invalid health-check metrics";
+    return result;
+  }
+  if (result.http_status < 200 || result.http_status >= 300) {
+    result.error =
+        "health endpoint returned HTTP " +
+        std::to_string(result.http_status);
+    return result;
+  }
+  if (result.downloaded_bytes < settings.minimum_bytes) {
+    result.error =
+        "downloaded " + std::to_string(result.downloaded_bytes) +
+        " bytes, expected at least " +
+        std::to_string(settings.minimum_bytes);
+    return result;
+  }
+
+  result.healthy = true;
+  return result;
+}
+
+}  // namespace defyx_cli

--- a/linux/cli/src/health_check.h
+++ b/linux/cli/src/health_check.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace defyx_cli {
+
+struct HealthCheckSettings {
+  std::string proxy_address = "127.0.0.1";
+  uint16_t proxy_port = 5000;
+  std::string url;
+  uint64_t minimum_bytes = 0;
+  int timeout_seconds = 20;
+  std::string curl_executable = "curl";
+};
+
+struct HealthCheckResult {
+  bool healthy = false;
+  int http_status = 0;
+  uint64_t downloaded_bytes = 0;
+  int exit_code = -1;
+  std::string error;
+};
+
+HealthCheckResult RunHttpsHealthCheck(
+    const HealthCheckSettings& settings);
+std::vector<std::string> SplitConnectionMethods(
+    const std::string& pattern);
+
+}  // namespace defyx_cli

--- a/linux/cli/src/main.cpp
+++ b/linux/cli/src/main.cpp
@@ -1,5 +1,6 @@
 #include "cli_options.h"
 #include "flowline.h"
+#include "health_check.h"
 #include "progress.h"
 #include "status_file.h"
 #include "tcp_forwarder.h"
@@ -133,8 +134,10 @@ defyx_cli::FlowLineResult ResolveFlowLine(
 class RuntimeTracker {
  public:
   RuntimeTracker(std::string cache_directory, bool quiet,
-                 std::string endpoint)
-      : cache_directory_(std::move(cache_directory)), quiet_(quiet) {
+                 std::string endpoint, bool requires_health_check)
+      : cache_directory_(std::move(cache_directory)),
+        quiet_(quiet),
+        requires_health_check_(requires_health_check) {
     status_.pid = static_cast<int64_t>(getpid());
     status_.started_at = static_cast<int64_t>(std::time(nullptr));
     status_.state = "starting";
@@ -147,12 +150,26 @@ class RuntimeTracker {
     return WriteStatusLocked(error);
   }
 
-  void HandleProgress(const std::string& message) {
+  uint64_t BeginAttempt() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    ++attempt_generation_;
+    core_connected_ = false;
+    terminal_event_ = defyx_cli::ProgressEvent::none;
+    status_.state = "connecting";
+    std::string ignored;
+    WriteStatusLocked(&ignored);
+    const uint64_t generation = attempt_generation_;
+    lock.unlock();
+    condition_.notify_all();
+    return generation;
+  }
+
+  void HandleProgress(const std::string& message, uint64_t generation) {
     const defyx_cli::ProgressEvent event =
         defyx_cli::ParseProgressEvent(message);
 
     std::unique_lock<std::mutex> lock(mutex_);
-    if (!active_) {
+    if (!active_ || generation != attempt_generation_) {
       return;
     }
     if (!quiet_ || event != defyx_cli::ProgressEvent::none) {
@@ -164,7 +181,7 @@ class RuntimeTracker {
         status_.state = "connecting";
         break;
       case defyx_cli::ProgressEvent::connected:
-        SetConnectedLocked();
+        SetCoreConnectedLocked();
         break;
       case defyx_cli::ProgressEvent::failed:
         status_.state = "failed";
@@ -184,17 +201,31 @@ class RuntimeTracker {
     condition_.notify_all();
   }
 
-  void MarkConnecting() {
-    UpdateState("connecting", defyx_cli::ProgressEvent::none);
+  void MarkCoreConnected(uint64_t generation) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!active_ || generation != attempt_generation_ ||
+        terminal_event_ != defyx_cli::ProgressEvent::none) {
+      return;
+    }
+    SetCoreConnectedLocked();
+    std::string ignored;
+    WriteStatusLocked(&ignored);
+    lock.unlock();
+    condition_.notify_all();
   }
 
-  void MarkConnected() {
+  bool MarkHealthy(uint64_t generation) {
     std::unique_lock<std::mutex> lock(mutex_);
+    if (!active_ || generation != attempt_generation_ ||
+        terminal_event_ != defyx_cli::ProgressEvent::none) {
+      return false;
+    }
     SetConnectedLocked();
     std::string ignored;
     WriteStatusLocked(&ignored);
     lock.unlock();
     condition_.notify_all();
+    return true;
   }
 
   void MarkStopping() {
@@ -211,8 +242,16 @@ class RuntimeTracker {
     return connected_;
   }
 
-  defyx_cli::ProgressEvent terminal_event() const {
+  bool core_connected(uint64_t generation) const {
     std::lock_guard<std::mutex> lock(mutex_);
+    return generation == attempt_generation_ && core_connected_;
+  }
+
+  defyx_cli::ProgressEvent terminal_event(uint64_t generation) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (generation != attempt_generation_) {
+      return defyx_cli::ProgressEvent::none;
+    }
     return terminal_event_;
   }
 
@@ -222,6 +261,15 @@ class RuntimeTracker {
   }
 
  private:
+  void SetCoreConnectedLocked() {
+    core_connected_ = true;
+    if (requires_health_check_) {
+      status_.state = "checking";
+    } else {
+      SetConnectedLocked();
+    }
+  }
+
   void SetConnectedLocked() {
     status_.state = "connected";
     if (!connected_) {
@@ -251,11 +299,14 @@ class RuntimeTracker {
 
   std::string cache_directory_;
   bool quiet_;
+  bool requires_health_check_;
   mutable std::mutex mutex_;
   std::condition_variable condition_;
   defyx_cli::RuntimeStatus status_;
   defyx_cli::ProgressEvent terminal_event_ =
       defyx_cli::ProgressEvent::none;
+  uint64_t attempt_generation_ = 0;
+  bool core_connected_ = false;
   bool connected_ = false;
   bool active_ = true;
 };
@@ -367,7 +418,7 @@ int Connect(const defyx_cli::Options& options) {
   }
 
   RuntimeTracker tracker(options.cache_directory, options.quiet,
-                         proxy_endpoint);
+                         proxy_endpoint, options.health_check);
   if (!tracker.Initialize(&error)) {
     std::cerr << "error: " << error << std::endl;
     return 2;
@@ -391,7 +442,9 @@ int Connect(const defyx_cli::Options& options) {
 
   defyx_core::EnableVerboseLogs(options.verbose);
   defyx_core::RegisterProgressHandler(
-      [&tracker](std::string message) { tracker.HandleProgress(message); });
+      [&tracker](std::string message) {
+        tracker.HandleProgress(message, 0);
+      });
   defyx_core::SetCacheDir(options.cache_directory);
   defyx_core::SetTimeZone(LocalUtcOffsetHours());
   defyx_core::SetAsnName();
@@ -424,6 +477,18 @@ int Connect(const defyx_cli::Options& options) {
     return 2;
   }
 
+  const std::vector<std::string> connection_methods =
+      options.health_check
+          ? defyx_cli::SplitConnectionMethods(pattern)
+          : std::vector<std::string> {pattern};
+  if (connection_methods.empty()) {
+    std::cerr << "error: --pattern does not contain a connection method"
+              << std::endl;
+    detach_progress();
+    remove_status();
+    return 2;
+  }
+
   if (!options.quiet) {
     std::cout << "Starting DefyxVPN in the foreground. Press Ctrl+C to stop."
               << '\n';
@@ -432,55 +497,171 @@ int Connect(const defyx_cli::Options& options) {
     }
     std::cout << std::flush;
   }
-  tracker.MarkConnecting();
-
-  if (!defyx_core::StartVPN(options.cache_directory, flowline.value,
-                            pattern, options.deep_scan,
-                            options.health_check)) {
-    std::cerr << "error: DXcore rejected the connection request";
-    const std::string core_error = defyx_core::GetLastError();
-    if (!core_error.empty()) {
-      std::cerr << ": " << core_error;
-    }
-    std::cerr << std::endl;
-    detach_progress();
-    remove_status();
-    return 2;
-  }
 
   const auto connection_started = std::chrono::steady_clock::now();
-  auto next_status_poll = connection_started;
   int result = 0;
+  bool connection_ready = false;
+  uint64_t active_generation = 0;
 
-  while (g_shutdown_signal == 0) {
-    const defyx_cli::ProgressEvent terminal_event = tracker.terminal_event();
-    if (terminal_event == defyx_cli::ProgressEvent::failed) {
-      std::cerr << "Connection failed." << std::endl;
-      result = kConnectionFailureExitCode;
-      break;
-    }
-    if (terminal_event == defyx_cli::ProgressEvent::stopped) {
-      std::cerr << "DXcore stopped unexpectedly." << std::endl;
-      result = kConnectionFailureExitCode;
-      break;
+  const auto stop_attempt = []() {
+    defyx_core::RegisterProgressHandler(nullptr);
+    defyx_core::StopVPN();
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  };
+
+  for (size_t method_index = 0;
+       method_index < connection_methods.size() &&
+       g_shutdown_signal == 0;
+       ++method_index) {
+    const std::string& method = connection_methods[method_index];
+    active_generation = tracker.BeginAttempt();
+    defyx_core::RegisterProgressHandler(
+        [&tracker, active_generation](std::string message) {
+          tracker.HandleProgress(message, active_generation);
+        });
+
+    if (options.health_check) {
+      std::cout << "Trying connection method: " << method << std::endl;
     }
 
-    const auto now = std::chrono::steady_clock::now();
-    if (!tracker.connected() && options.timeout_seconds > 0 &&
-        now - connection_started >=
-            std::chrono::seconds(options.timeout_seconds)) {
-      std::cerr << "Connection timed out after " << options.timeout_seconds
-                << " seconds." << std::endl;
-      result = kConnectionFailureExitCode;
-      break;
-    }
+    const bool request_accepted =
+        defyx_core::StartVPN(options.cache_directory, flowline.value,
+                             method, options.deep_scan,
+                             options.health_check);
+    bool attempt_failed = !request_accepted;
+    bool timed_out = false;
+    bool health_checker_failed = false;
+    auto next_status_poll = std::chrono::steady_clock::now();
 
-    if (now >= next_status_poll) {
-      const std::string core_status = defyx_core::GetVpnStatus();
-      if (core_status == "connected" && !tracker.connected()) {
-        tracker.MarkConnected();
+    if (!request_accepted) {
+      std::cerr << (options.health_check ? "warning: " : "error: ")
+                << "DXcore rejected "
+                << (options.health_check ? method : "the connection request");
+      const std::string core_error = defyx_core::GetLastError();
+      if (!core_error.empty()) {
+        std::cerr << ": " << core_error;
       }
-      next_status_poll = now + std::chrono::seconds(2);
+      std::cerr << std::endl;
+      if (!options.health_check) {
+        result = 2;
+      }
+    }
+
+    while (!attempt_failed && g_shutdown_signal == 0) {
+      const defyx_cli::ProgressEvent terminal_event =
+          tracker.terminal_event(active_generation);
+      if (terminal_event == defyx_cli::ProgressEvent::failed ||
+          terminal_event == defyx_cli::ProgressEvent::stopped) {
+        std::cerr
+            << (options.health_check ? "warning: " : "")
+            << (terminal_event == defyx_cli::ProgressEvent::failed
+                    ? "Connection failed"
+                    : "DXcore stopped unexpectedly");
+        if (options.health_check) {
+          std::cerr << " for " << method;
+        }
+        std::cerr << "." << std::endl;
+        attempt_failed = true;
+        break;
+      }
+
+      const auto now = std::chrono::steady_clock::now();
+      if (options.timeout_seconds > 0 &&
+          now - connection_started >=
+              std::chrono::seconds(options.timeout_seconds)) {
+        std::cerr << "Connection timed out after "
+                  << options.timeout_seconds << " seconds." << std::endl;
+        result = kConnectionFailureExitCode;
+        timed_out = true;
+        break;
+      }
+
+      if (now >= next_status_poll) {
+        if (defyx_core::GetVpnStatus() == "connected" &&
+            !tracker.core_connected(active_generation)) {
+          tracker.MarkCoreConnected(active_generation);
+        }
+        next_status_poll = now + std::chrono::seconds(2);
+      }
+
+      if (tracker.core_connected(active_generation)) {
+        if (!options.health_check) {
+          connection_ready = tracker.connected();
+          break;
+        }
+
+        if (!options.quiet) {
+          std::cout << "Checking HTTPS connectivity through " << method
+                    << "..." << std::endl;
+        }
+        defyx_cli::HealthCheckSettings health_settings;
+        health_settings.proxy_address = kCoreProxyAddress;
+        health_settings.proxy_port = kCoreProxyPort;
+        health_settings.url = options.health_check_url;
+        health_settings.minimum_bytes =
+            static_cast<uint64_t>(options.health_check_min_bytes);
+        health_settings.timeout_seconds =
+            options.health_check_timeout_seconds;
+        const defyx_cli::HealthCheckResult health =
+            defyx_cli::RunHttpsHealthCheck(health_settings);
+
+        if (health.healthy) {
+          if (!options.quiet) {
+            std::cout << "Health check passed for " << method << ": HTTP "
+                      << health.http_status << ", "
+                      << health.downloaded_bytes << " bytes." << std::endl;
+          }
+          connection_ready =
+              tracker.MarkHealthy(active_generation);
+        } else {
+          std::cerr << "warning: health check failed for " << method
+                    << ": " << health.error;
+          if (health.http_status != 0 ||
+              health.downloaded_bytes != 0) {
+            std::cerr << " (HTTP " << health.http_status << ", "
+                      << health.downloaded_bytes << " bytes)";
+          }
+          std::cerr << std::endl;
+          attempt_failed = true;
+          health_checker_failed = health.exit_code < 0;
+          if (health_checker_failed) {
+            result = 2;
+          }
+        }
+        break;
+      }
+
+      tracker.WaitForUpdate(std::chrono::milliseconds(250));
+    }
+
+    if (connection_ready || g_shutdown_signal != 0 ||
+        timed_out || health_checker_failed || result == 2) {
+      break;
+    }
+
+    const bool has_next_method =
+        method_index + 1 < connection_methods.size();
+    if (has_next_method) {
+      stop_attempt();
+      std::cerr << "Trying the next connection method." << std::endl;
+      continue;
+    }
+
+    result = kConnectionFailureExitCode;
+  }
+
+  while (connection_ready && g_shutdown_signal == 0) {
+    const defyx_cli::ProgressEvent terminal_event =
+        tracker.terminal_event(active_generation);
+    if (terminal_event == defyx_cli::ProgressEvent::failed ||
+        terminal_event == defyx_cli::ProgressEvent::stopped) {
+      std::cerr
+          << (terminal_event == defyx_cli::ProgressEvent::failed
+                  ? "Connection failed."
+                  : "DXcore stopped unexpectedly.")
+          << std::endl;
+      result = kConnectionFailureExitCode;
+      break;
     }
     tracker.WaitForUpdate(std::chrono::milliseconds(250));
   }
@@ -489,6 +670,7 @@ int Connect(const defyx_cli::Options& options) {
   if (!options.quiet) {
     std::cout << "Stopping DefyxVPN..." << std::endl;
   }
+  defyx_core::RegisterProgressHandler(nullptr);
   defyx_core::StopVPN();
   defyx_core::Stop();
   std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/linux/cli/src/main.cpp
+++ b/linux/cli/src/main.cpp
@@ -154,6 +154,7 @@ class RuntimeTracker {
     std::unique_lock<std::mutex> lock(mutex_);
     ++attempt_generation_;
     core_connected_ = false;
+    connected_ = false;
     terminal_event_ = defyx_cli::ProgressEvent::none;
     status_.state = "connecting";
     std::string ignored;
@@ -498,7 +499,7 @@ int Connect(const defyx_cli::Options& options) {
     std::cout << std::flush;
   }
 
-  const auto connection_started = std::chrono::steady_clock::now();
+  auto connection_started = std::chrono::steady_clock::now();
   int result = 0;
   bool connection_ready = false;
   uint64_t active_generation = 0;
@@ -507,6 +508,17 @@ int Connect(const defyx_cli::Options& options) {
     defyx_core::RegisterProgressHandler(nullptr);
     defyx_core::StopVPN();
     std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  };
+
+  const auto run_health_check = [&options]() {
+    defyx_cli::HealthCheckSettings settings;
+    settings.proxy_address = kCoreProxyAddress;
+    settings.proxy_port = kCoreProxyPort;
+    settings.url = options.health_check_url;
+    settings.minimum_bytes =
+        static_cast<uint64_t>(options.health_check_min_bytes);
+    settings.timeout_seconds = options.health_check_timeout_seconds;
+    return defyx_cli::RunHttpsHealthCheck(settings);
   };
 
   for (size_t method_index = 0;
@@ -531,6 +543,7 @@ int Connect(const defyx_cli::Options& options) {
     bool attempt_failed = !request_accepted;
     bool timed_out = false;
     bool health_checker_failed = false;
+    bool runtime_failed = false;
     auto next_status_poll = std::chrono::steady_clock::now();
 
     if (!request_accepted) {
@@ -594,16 +607,8 @@ int Connect(const defyx_cli::Options& options) {
           std::cout << "Checking HTTPS connectivity through " << method
                     << "..." << std::endl;
         }
-        defyx_cli::HealthCheckSettings health_settings;
-        health_settings.proxy_address = kCoreProxyAddress;
-        health_settings.proxy_port = kCoreProxyPort;
-        health_settings.url = options.health_check_url;
-        health_settings.minimum_bytes =
-            static_cast<uint64_t>(options.health_check_min_bytes);
-        health_settings.timeout_seconds =
-            options.health_check_timeout_seconds;
         const defyx_cli::HealthCheckResult health =
-            defyx_cli::RunHttpsHealthCheck(health_settings);
+            run_health_check();
 
         if (health.healthy) {
           if (!options.quiet) {
@@ -634,6 +639,81 @@ int Connect(const defyx_cli::Options& options) {
       tracker.WaitForUpdate(std::chrono::milliseconds(250));
     }
 
+    if (connection_ready) {
+      int consecutive_health_failures = 0;
+      const auto health_check_interval = std::chrono::seconds(
+          options.health_check_interval_seconds);
+      auto next_health_check =
+          std::chrono::steady_clock::now() + health_check_interval;
+
+      while (connection_ready && g_shutdown_signal == 0) {
+        const defyx_cli::ProgressEvent terminal_event =
+            tracker.terminal_event(active_generation);
+        if (terminal_event == defyx_cli::ProgressEvent::failed ||
+            terminal_event == defyx_cli::ProgressEvent::stopped) {
+          std::cerr
+              << (terminal_event == defyx_cli::ProgressEvent::failed
+                      ? "Connection failed."
+                      : "DXcore stopped unexpectedly.")
+              << std::endl;
+          runtime_failed = true;
+          connection_ready = false;
+          break;
+        }
+
+        const auto now = std::chrono::steady_clock::now();
+        if (options.health_check &&
+            options.health_check_interval_seconds > 0 &&
+            now >= next_health_check) {
+          const defyx_cli::HealthCheckResult health =
+              run_health_check();
+          next_health_check =
+              std::chrono::steady_clock::now() + health_check_interval;
+
+          if (health.healthy) {
+            if (consecutive_health_failures > 0) {
+              std::cout << "Runtime health check recovered for " << method
+                        << "." << std::endl;
+            }
+            consecutive_health_failures = 0;
+            continue;
+          }
+
+          ++consecutive_health_failures;
+          std::cerr << "warning: runtime health check failed for " << method
+                    << " (" << consecutive_health_failures << "/"
+                    << options.health_check_failures << "): "
+                    << health.error;
+          if (health.http_status != 0 ||
+              health.downloaded_bytes != 0) {
+            std::cerr << " (HTTP " << health.http_status << ", "
+                      << health.downloaded_bytes << " bytes)";
+          }
+          std::cerr << std::endl;
+
+          if (health.exit_code < 0) {
+            health_checker_failed = true;
+            result = 2;
+            connection_ready = false;
+            break;
+          }
+          if (consecutive_health_failures >=
+              options.health_check_failures) {
+            std::cerr << "Connection method " << method << " failed "
+                      << consecutive_health_failures
+                      << " consecutive runtime health checks."
+                      << std::endl;
+            runtime_failed = true;
+            connection_ready = false;
+            break;
+          }
+          continue;
+        }
+
+        tracker.WaitForUpdate(std::chrono::milliseconds(250));
+      }
+    }
+
     if (connection_ready || g_shutdown_signal != 0 ||
         timed_out || health_checker_failed || result == 2) {
       break;
@@ -643,27 +723,14 @@ int Connect(const defyx_cli::Options& options) {
         method_index + 1 < connection_methods.size();
     if (has_next_method) {
       stop_attempt();
+      if (runtime_failed) {
+        connection_started = std::chrono::steady_clock::now();
+      }
       std::cerr << "Trying the next connection method." << std::endl;
       continue;
     }
 
     result = kConnectionFailureExitCode;
-  }
-
-  while (connection_ready && g_shutdown_signal == 0) {
-    const defyx_cli::ProgressEvent terminal_event =
-        tracker.terminal_event(active_generation);
-    if (terminal_event == defyx_cli::ProgressEvent::failed ||
-        terminal_event == defyx_cli::ProgressEvent::stopped) {
-      std::cerr
-          << (terminal_event == defyx_cli::ProgressEvent::failed
-                  ? "Connection failed."
-                  : "DXcore stopped unexpectedly.")
-          << std::endl;
-      result = kConnectionFailureExitCode;
-      break;
-    }
-    tracker.WaitForUpdate(std::chrono::milliseconds(250));
   }
 
   tracker.MarkStopping();

--- a/linux/cli/src/main.cpp
+++ b/linux/cli/src/main.cpp
@@ -1,0 +1,539 @@
+#include "cli_options.h"
+#include "flowline.h"
+#include "progress.h"
+#include "status_file.h"
+#include "tcp_forwarder.h"
+
+#include "defyx_core.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <csignal>
+#include <cstdint>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <cerrno>
+#include <cstring>
+#include <unistd.h>
+
+#ifndef DEFYX_CLI_VERSION
+#define DEFYX_CLI_VERSION "dev"
+#endif
+
+namespace {
+
+constexpr const char* kCoreProxyAddress = "127.0.0.1";
+constexpr uint16_t kCoreProxyPort = 5000;
+constexpr uintmax_t kMaximumFlowLineSize = 16U * 1024U * 1024U;
+constexpr int kNotRunningExitCode = 3;
+constexpr int kConnectionFailureExitCode = 4;
+
+volatile std::sig_atomic_t g_shutdown_signal = 0;
+
+void HandleSignal(int signal_number) {
+  g_shutdown_signal = signal_number;
+}
+
+std::string ReadFile(const std::string& path, std::string* error) {
+  std::error_code filesystem_error;
+  const uintmax_t size = std::filesystem::file_size(path, filesystem_error);
+  if (filesystem_error) {
+    if (error != nullptr) {
+      *error = "cannot inspect " + path + ": " + filesystem_error.message();
+    }
+    return {};
+  }
+  if (size > kMaximumFlowLineSize) {
+    if (error != nullptr) {
+      *error = "flowline file is larger than 16 MiB";
+    }
+    return {};
+  }
+
+  std::ifstream stream(path, std::ios::in | std::ios::binary);
+  if (!stream) {
+    if (error != nullptr) {
+      *error = "cannot read " + path;
+    }
+    return {};
+  }
+  return std::string((std::istreambuf_iterator<char>(stream)),
+                     std::istreambuf_iterator<char>());
+}
+
+float LocalUtcOffsetHours() {
+  const std::time_t now = std::time(nullptr);
+  std::tm local_time {};
+  std::tm utc_time {};
+  localtime_r(&now, &local_time);
+  gmtime_r(&now, &utc_time);
+
+  local_time.tm_isdst = -1;
+  utc_time.tm_isdst = -1;
+  const double seconds =
+      std::difftime(std::mktime(&local_time), std::mktime(&utc_time));
+  return static_cast<float>(seconds / 3600.0);
+}
+
+defyx_cli::FlowLineResult ResolveFlowLine(
+    const defyx_cli::Options& options) {
+  if (!options.flowline_file.empty()) {
+    std::string read_error;
+    const std::string file_payload =
+        ReadFile(options.flowline_file, &read_error);
+    if (!read_error.empty()) {
+      defyx_cli::FlowLineResult result;
+      result.error = read_error;
+      return result;
+    }
+
+    // Exported offline flowlines are signed. Prefer the verified representation,
+    // while still accepting a raw flowLine object for advanced deployments.
+    const std::string verified =
+        defyx_core::DecodeAndVerifyFlowline(file_payload);
+    if (!verified.empty()) {
+      defyx_cli::FlowLineResult result =
+          defyx_cli::NormalizeFlowLine(verified);
+      if (result.ok()) {
+        return result;
+      }
+    }
+    return defyx_cli::NormalizeFlowLine(file_payload);
+  }
+
+  std::string payload = options.cached_flowline
+                            ? defyx_core::GetCachedFlowLine()
+                            : defyx_core::GetFlowLine(options.test_flowline);
+  defyx_cli::FlowLineResult result =
+      defyx_cli::NormalizeFlowLine(payload);
+  if (result.ok() || options.cached_flowline) {
+    return result;
+  }
+
+  const std::string cached = defyx_core::GetCachedFlowLine();
+  defyx_cli::FlowLineResult cached_result =
+      defyx_cli::NormalizeFlowLine(cached);
+  if (cached_result.ok()) {
+    return cached_result;
+  }
+
+  result.error += "; cached flowline is also unavailable: " +
+                  cached_result.error;
+  return result;
+}
+
+class RuntimeTracker {
+ public:
+  RuntimeTracker(std::string cache_directory, bool quiet,
+                 std::string endpoint)
+      : cache_directory_(std::move(cache_directory)), quiet_(quiet) {
+    status_.pid = static_cast<int64_t>(getpid());
+    status_.started_at = static_cast<int64_t>(std::time(nullptr));
+    status_.state = "starting";
+    status_.endpoint = std::move(endpoint);
+    status_.version = DEFYX_CLI_VERSION;
+  }
+
+  bool Initialize(std::string* error) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return WriteStatusLocked(error);
+  }
+
+  void HandleProgress(const std::string& message) {
+    const defyx_cli::ProgressEvent event =
+        defyx_cli::ParseProgressEvent(message);
+
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!active_) {
+      return;
+    }
+    if (!quiet_ || event != defyx_cli::ProgressEvent::none) {
+      std::cout << message << std::endl;
+    }
+
+    switch (event) {
+      case defyx_cli::ProgressEvent::connecting:
+        status_.state = "connecting";
+        break;
+      case defyx_cli::ProgressEvent::connected:
+        SetConnectedLocked();
+        break;
+      case defyx_cli::ProgressEvent::failed:
+        status_.state = "failed";
+        terminal_event_ = event;
+        break;
+      case defyx_cli::ProgressEvent::stopped:
+        status_.state = "stopped";
+        terminal_event_ = event;
+        break;
+      case defyx_cli::ProgressEvent::none:
+        return;
+    }
+
+    std::string ignored;
+    WriteStatusLocked(&ignored);
+    lock.unlock();
+    condition_.notify_all();
+  }
+
+  void MarkConnecting() {
+    UpdateState("connecting", defyx_cli::ProgressEvent::none);
+  }
+
+  void MarkConnected() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    SetConnectedLocked();
+    std::string ignored;
+    WriteStatusLocked(&ignored);
+    lock.unlock();
+    condition_.notify_all();
+  }
+
+  void MarkStopping() {
+    UpdateState("stopping", defyx_cli::ProgressEvent::none);
+  }
+
+  void Deactivate() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    active_ = false;
+  }
+
+  bool connected() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return connected_;
+  }
+
+  defyx_cli::ProgressEvent terminal_event() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return terminal_event_;
+  }
+
+  void WaitForUpdate(std::chrono::milliseconds duration) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    condition_.wait_for(lock, duration);
+  }
+
+ private:
+  void SetConnectedLocked() {
+    status_.state = "connected";
+    if (!connected_) {
+      connected_ = true;
+      std::cout << "Connected. SOCKS5 proxy: " << status_.endpoint << '\n'
+                << "Example: curl --proxy " << status_.endpoint
+                << " https://ifconfig.me" << std::endl;
+    }
+  }
+
+  void UpdateState(const std::string& state,
+                   defyx_cli::ProgressEvent terminal_event) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    status_.state = state;
+    if (terminal_event != defyx_cli::ProgressEvent::none) {
+      terminal_event_ = terminal_event;
+    }
+    std::string ignored;
+    WriteStatusLocked(&ignored);
+    lock.unlock();
+    condition_.notify_all();
+  }
+
+  bool WriteStatusLocked(std::string* error) const {
+    return defyx_cli::WriteRuntimeStatus(cache_directory_, status_, error);
+  }
+
+  std::string cache_directory_;
+  bool quiet_;
+  mutable std::mutex mutex_;
+  std::condition_variable condition_;
+  defyx_cli::RuntimeStatus status_;
+  defyx_cli::ProgressEvent terminal_event_ =
+      defyx_cli::ProgressEvent::none;
+  bool connected_ = false;
+  bool active_ = true;
+};
+
+int ShowStatus(const defyx_cli::Options& options) {
+  defyx_cli::RuntimeStatus status;
+  std::string error;
+  if (!defyx_cli::ReadRuntimeStatus(options.cache_directory, &status, &error)) {
+    std::cout << "DefyxVPN CLI is not running." << std::endl;
+    return kNotRunningExitCode;
+  }
+
+  if (!defyx_cli::ProcessExists(status.pid) ||
+      !defyx_cli::IsDefyxCliProcess(status.pid)) {
+    std::string ignored;
+    defyx_cli::RemoveRuntimeStatus(options.cache_directory, &ignored);
+    std::cout << "DefyxVPN CLI is not running (removed stale status)."
+              << std::endl;
+    return kNotRunningExitCode;
+  }
+
+  std::time_t started_at = static_cast<std::time_t>(status.started_at);
+  std::tm local_time {};
+  localtime_r(&started_at, &local_time);
+
+  std::cout << "State:    " << status.state << '\n'
+            << "PID:      " << status.pid << '\n'
+            << "Endpoint: " << status.endpoint << '\n'
+            << "Started:  " << std::put_time(&local_time, "%Y-%m-%d %H:%M:%S")
+            << '\n'
+            << "Version:  " << status.version << std::endl;
+  return 0;
+}
+
+int Disconnect(const defyx_cli::Options& options) {
+  defyx_cli::RuntimeStatus status;
+  std::string error;
+  if (!defyx_cli::ReadRuntimeStatus(options.cache_directory, &status, &error) ||
+      !defyx_cli::ProcessExists(status.pid)) {
+    std::cout << "DefyxVPN CLI is not running." << std::endl;
+    return kNotRunningExitCode;
+  }
+
+  if (!defyx_cli::IsDefyxCliProcess(status.pid)) {
+    std::cerr << "Refusing to signal PID " << status.pid
+              << ": it is not a DefyxVPN CLI process." << std::endl;
+    return kNotRunningExitCode;
+  }
+
+  if (kill(static_cast<pid_t>(status.pid), SIGTERM) != 0 && errno != ESRCH) {
+    std::cerr << "Failed to stop PID " << status.pid << ": "
+              << std::strerror(errno) << std::endl;
+    return 2;
+  }
+
+  for (int attempt = 0; attempt < 50; ++attempt) {
+    if (!defyx_cli::ProcessExists(status.pid)) {
+      std::string ignored;
+      defyx_cli::RemoveRuntimeStatus(options.cache_directory, &ignored);
+      std::cout << "Disconnected." << std::endl;
+      return 0;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  std::cerr << "Stop signal sent, but PID " << status.pid
+            << " is still running." << std::endl;
+  return 2;
+}
+
+int Connect(const defyx_cli::Options& options) {
+  std::string error;
+  defyx_cli::InstanceLock instance_lock;
+  if (!instance_lock.Acquire(options.cache_directory, &error)) {
+    std::cerr << "error: " << error << std::endl;
+    return 2;
+  }
+
+  const uint16_t listen_port =
+      static_cast<uint16_t>(options.listen_port);
+  const bool uses_core_endpoint =
+      options.listen_address == kCoreProxyAddress &&
+      listen_port == kCoreProxyPort;
+  if (!uses_core_endpoint && options.listen_address == "0.0.0.0" &&
+      listen_port == kCoreProxyPort) {
+    std::cerr
+        << "error: 0.0.0.0:5000 conflicts with DXcore's internal "
+           "127.0.0.1:5000 listener; choose another --listen-port"
+        << std::endl;
+    return 2;
+  }
+
+  defyx_cli::TcpForwarder forwarder;
+  if (!uses_core_endpoint &&
+      !forwarder.Start(options.listen_address, listen_port,
+                       kCoreProxyAddress, kCoreProxyPort, &error)) {
+    std::cerr << "error: " << error << std::endl;
+    return 2;
+  }
+
+  const std::string proxy_endpoint =
+      defyx_cli::FormatSocksEndpoint(options.listen_address, listen_port);
+  if (!defyx_cli::IsLoopbackAddress(options.listen_address)) {
+    std::cerr
+        << "warning: exposing an unauthenticated SOCKS5 proxy on "
+        << proxy_endpoint
+        << "; restrict access with the host or network firewall"
+        << std::endl;
+  }
+
+  RuntimeTracker tracker(options.cache_directory, options.quiet,
+                         proxy_endpoint);
+  if (!tracker.Initialize(&error)) {
+    std::cerr << "error: " << error << std::endl;
+    return 2;
+  }
+
+  const auto remove_status = [&options]() {
+    std::string ignored;
+    defyx_cli::RemoveRuntimeStatus(options.cache_directory, &ignored);
+  };
+
+  if (!defyx_core::LoadCoreDll(options.core_library)) {
+    std::cerr << "error: could not load libdxcore_amd64.so";
+    const std::string core_error = defyx_core::GetLastError();
+    if (!core_error.empty()) {
+      std::cerr << ": " << core_error;
+    }
+    std::cerr << std::endl;
+    remove_status();
+    return 2;
+  }
+
+  defyx_core::EnableVerboseLogs(options.verbose);
+  defyx_core::RegisterProgressHandler(
+      [&tracker](std::string message) { tracker.HandleProgress(message); });
+  defyx_core::SetCacheDir(options.cache_directory);
+  defyx_core::SetTimeZone(LocalUtcOffsetHours());
+  defyx_core::SetAsnName();
+
+  const auto detach_progress = [&tracker]() {
+    defyx_core::RegisterProgressHandler(nullptr);
+    tracker.Deactivate();
+  };
+
+  const defyx_cli::FlowLineResult flowline = ResolveFlowLine(options);
+  if (!flowline.ok()) {
+    std::cerr << "error: unable to prepare a flowline: " << flowline.error
+              << '\n'
+              << "Provide an exported configuration with --flowline-file."
+              << std::endl;
+    detach_progress();
+    remove_status();
+    return 2;
+  }
+
+  const std::string pattern =
+      options.pattern.empty() ? flowline.default_pattern : options.pattern;
+  if (pattern.empty()) {
+    std::cerr
+        << "error: the flowline has no enabled labeled connection methods; "
+           "provide --pattern explicitly"
+        << std::endl;
+    detach_progress();
+    remove_status();
+    return 2;
+  }
+
+  if (!options.quiet) {
+    std::cout << "Starting DefyxVPN in the foreground. Press Ctrl+C to stop."
+              << '\n';
+    if (options.pattern.empty()) {
+      std::cout << "Using enabled connection methods: " << pattern << '\n';
+    }
+    std::cout << std::flush;
+  }
+  tracker.MarkConnecting();
+
+  if (!defyx_core::StartVPN(options.cache_directory, flowline.value,
+                            pattern, options.deep_scan,
+                            options.health_check)) {
+    std::cerr << "error: DXcore rejected the connection request";
+    const std::string core_error = defyx_core::GetLastError();
+    if (!core_error.empty()) {
+      std::cerr << ": " << core_error;
+    }
+    std::cerr << std::endl;
+    detach_progress();
+    remove_status();
+    return 2;
+  }
+
+  const auto connection_started = std::chrono::steady_clock::now();
+  auto next_status_poll = connection_started;
+  int result = 0;
+
+  while (g_shutdown_signal == 0) {
+    const defyx_cli::ProgressEvent terminal_event = tracker.terminal_event();
+    if (terminal_event == defyx_cli::ProgressEvent::failed) {
+      std::cerr << "Connection failed." << std::endl;
+      result = kConnectionFailureExitCode;
+      break;
+    }
+    if (terminal_event == defyx_cli::ProgressEvent::stopped) {
+      std::cerr << "DXcore stopped unexpectedly." << std::endl;
+      result = kConnectionFailureExitCode;
+      break;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    if (!tracker.connected() && options.timeout_seconds > 0 &&
+        now - connection_started >=
+            std::chrono::seconds(options.timeout_seconds)) {
+      std::cerr << "Connection timed out after " << options.timeout_seconds
+                << " seconds." << std::endl;
+      result = kConnectionFailureExitCode;
+      break;
+    }
+
+    if (now >= next_status_poll) {
+      const std::string core_status = defyx_core::GetVpnStatus();
+      if (core_status == "connected" && !tracker.connected()) {
+        tracker.MarkConnected();
+      }
+      next_status_poll = now + std::chrono::seconds(2);
+    }
+    tracker.WaitForUpdate(std::chrono::milliseconds(250));
+  }
+
+  tracker.MarkStopping();
+  if (!options.quiet) {
+    std::cout << "Stopping DefyxVPN..." << std::endl;
+  }
+  defyx_core::StopVPN();
+  defyx_core::Stop();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  detach_progress();
+  forwarder.Stop();
+  remove_status();
+
+  if (g_shutdown_signal != 0 && !options.quiet) {
+    std::cout << "Disconnected." << std::endl;
+  }
+  return result;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  std::vector<std::string> arguments;
+  arguments.reserve(argc > 1 ? static_cast<size_t>(argc - 1) : 0U);
+  for (int index = 1; index < argc; ++index) {
+    arguments.emplace_back(argv[index]);
+  }
+
+  const defyx_cli::ParseResult parsed =
+      defyx_cli::ParseOptions(arguments, defyx_cli::OptionsFromEnvironment());
+  if (!parsed.ok()) {
+    std::cerr << "error: " << parsed.error << "\n\n"
+              << defyx_cli::Usage();
+    return 1;
+  }
+
+  switch (parsed.options.command) {
+    case defyx_cli::Command::help:
+      std::cout << defyx_cli::Usage();
+      return 0;
+    case defyx_cli::Command::version:
+      std::cout << "defyxvpn-cli " << DEFYX_CLI_VERSION << std::endl;
+      return 0;
+    case defyx_cli::Command::status:
+      return ShowStatus(parsed.options);
+    case defyx_cli::Command::disconnect:
+      return Disconnect(parsed.options);
+    case defyx_cli::Command::connect:
+      std::signal(SIGINT, HandleSignal);
+      std::signal(SIGTERM, HandleSignal);
+      return Connect(parsed.options);
+  }
+  return 1;
+}

--- a/linux/cli/src/progress.cpp
+++ b/linux/cli/src/progress.cpp
@@ -1,0 +1,22 @@
+#include "progress.h"
+
+namespace defyx_cli {
+
+ProgressEvent ParseProgressEvent(const std::string& message) {
+  if (message.find("Data: VPN connected") != std::string::npos) {
+    return ProgressEvent::connected;
+  }
+  if (message.find("Data: VPN failed") != std::string::npos) {
+    return ProgressEvent::failed;
+  }
+  if (message.find("Data: VPN stopped") != std::string::npos ||
+      message.find("Data: VPN cancelled") != std::string::npos) {
+    return ProgressEvent::stopped;
+  }
+  if (message.find("Data: VPN connecting") != std::string::npos) {
+    return ProgressEvent::connecting;
+  }
+  return ProgressEvent::none;
+}
+
+}  // namespace defyx_cli

--- a/linux/cli/src/progress.h
+++ b/linux/cli/src/progress.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+namespace defyx_cli {
+
+enum class ProgressEvent {
+  none,
+  connecting,
+  connected,
+  failed,
+  stopped,
+};
+
+ProgressEvent ParseProgressEvent(const std::string& message);
+
+}  // namespace defyx_cli

--- a/linux/cli/src/status_file.cpp
+++ b/linux/cli/src/status_file.cpp
@@ -1,0 +1,304 @@
+#include "status_file.h"
+
+#include <json-c/json.h>
+
+#include <cerrno>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace defyx_cli {
+
+namespace {
+
+constexpr const char* kStatusFileName = "defyxvpn-cli.status.json";
+constexpr const char* kLockFileName = "defyxvpn-cli.lock";
+
+using JsonPointer = std::unique_ptr<json_object, decltype(&json_object_put)>;
+using TokenerPointer =
+    std::unique_ptr<json_tokener, decltype(&json_tokener_free)>;
+
+std::string ErrnoMessage(const std::string& operation) {
+  return operation + ": " + std::strerror(errno);
+}
+
+bool ReadInt64(json_object* root, const char* key, int64_t* value) {
+  json_object* field = nullptr;
+  if (!json_object_object_get_ex(root, key, &field) ||
+      json_object_get_type(field) != json_type_int) {
+    return false;
+  }
+  *value = json_object_get_int64(field);
+  return true;
+}
+
+bool ReadString(json_object* root, const char* key, std::string* value) {
+  json_object* field = nullptr;
+  if (!json_object_object_get_ex(root, key, &field) ||
+      json_object_get_type(field) != json_type_string) {
+    return false;
+  }
+  *value = json_object_get_string(field);
+  return true;
+}
+
+}  // namespace
+
+InstanceLock::~InstanceLock() {
+  if (file_descriptor_ >= 0) {
+    flock(file_descriptor_, LOCK_UN);
+    close(file_descriptor_);
+  }
+}
+
+bool InstanceLock::Acquire(const std::string& cache_directory,
+                           std::string* error) {
+  if (file_descriptor_ >= 0) {
+    return true;
+  }
+  if (!EnsurePrivateDirectory(cache_directory, error)) {
+    return false;
+  }
+
+  const std::filesystem::path path =
+      std::filesystem::path(cache_directory) / kLockFileName;
+  file_descriptor_ =
+      open(path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, S_IRUSR | S_IWUSR);
+  if (file_descriptor_ < 0) {
+    if (error != nullptr) {
+      *error = ErrnoMessage("cannot open " + path.string());
+    }
+    return false;
+  }
+
+  if (flock(file_descriptor_, LOCK_EX | LOCK_NB) != 0) {
+    if (error != nullptr) {
+      *error = errno == EWOULDBLOCK
+                   ? "another DefyxVPN CLI instance is already running"
+                   : ErrnoMessage("cannot lock " + path.string());
+    }
+    close(file_descriptor_);
+    file_descriptor_ = -1;
+    return false;
+  }
+  return true;
+}
+
+std::string StatusFilePath(const std::string& cache_directory) {
+  return (std::filesystem::path(cache_directory) / kStatusFileName).string();
+}
+
+bool EnsurePrivateDirectory(const std::string& directory, std::string* error) {
+  std::error_code filesystem_error;
+  std::filesystem::create_directories(directory, filesystem_error);
+  if (filesystem_error) {
+    if (error != nullptr) {
+      *error = "cannot create " + directory + ": " + filesystem_error.message();
+    }
+    return false;
+  }
+  if (!std::filesystem::is_directory(directory, filesystem_error)) {
+    if (error != nullptr) {
+      *error = directory + " is not a directory";
+    }
+    return false;
+  }
+  if (chmod(directory.c_str(), S_IRWXU) != 0) {
+    if (error != nullptr) {
+      *error = ErrnoMessage("cannot set permissions on " + directory);
+    }
+    return false;
+  }
+  return true;
+}
+
+bool WriteRuntimeStatus(const std::string& cache_directory,
+                        const RuntimeStatus& status, std::string* error) {
+  if (!EnsurePrivateDirectory(cache_directory, error)) {
+    return false;
+  }
+
+  JsonPointer root(json_object_new_object(), &json_object_put);
+  json_object_object_add(root.get(), "pid", json_object_new_int64(status.pid));
+  json_object_object_add(root.get(), "startedAt",
+                         json_object_new_int64(status.started_at));
+  json_object_object_add(root.get(), "state",
+                         json_object_new_string(status.state.c_str()));
+  json_object_object_add(root.get(), "endpoint",
+                         json_object_new_string(status.endpoint.c_str()));
+  json_object_object_add(root.get(), "version",
+                         json_object_new_string(status.version.c_str()));
+
+  const std::filesystem::path target = StatusFilePath(cache_directory);
+  const std::filesystem::path temporary =
+      target.string() + ".tmp." + std::to_string(static_cast<long long>(getpid()));
+
+  {
+    std::ofstream stream(temporary, std::ios::out | std::ios::trunc);
+    if (!stream) {
+      if (error != nullptr) {
+        *error = "cannot write " + temporary.string();
+      }
+      return false;
+    }
+    stream << json_object_to_json_string_ext(root.get(), JSON_C_TO_STRING_PLAIN)
+           << '\n';
+    if (!stream) {
+      if (error != nullptr) {
+        *error = "cannot finish writing " + temporary.string();
+      }
+      return false;
+    }
+  }
+
+  if (chmod(temporary.c_str(), S_IRUSR | S_IWUSR) != 0) {
+    if (error != nullptr) {
+      *error = ErrnoMessage("cannot set permissions on " + temporary.string());
+    }
+    std::error_code ignored;
+    std::filesystem::remove(temporary, ignored);
+    return false;
+  }
+
+  std::error_code filesystem_error;
+  std::filesystem::rename(temporary, target, filesystem_error);
+  if (filesystem_error) {
+    if (error != nullptr) {
+      *error = "cannot replace " + target.string() + ": " +
+               filesystem_error.message();
+    }
+    std::error_code ignored;
+    std::filesystem::remove(temporary, ignored);
+    return false;
+  }
+  return true;
+}
+
+bool ReadRuntimeStatus(const std::string& cache_directory,
+                       RuntimeStatus* status, std::string* error) {
+  if (status == nullptr) {
+    if (error != nullptr) {
+      *error = "status output is null";
+    }
+    return false;
+  }
+
+  const std::string path = StatusFilePath(cache_directory);
+  std::ifstream stream(path);
+  if (!stream) {
+    if (error != nullptr) {
+      *error = "no runtime status at " + path;
+    }
+    return false;
+  }
+
+  std::string payload((std::istreambuf_iterator<char>(stream)),
+                      std::istreambuf_iterator<char>());
+  TokenerPointer tokener(json_tokener_new(), &json_tokener_free);
+  json_tokener_set_flags(tokener.get(), JSON_TOKENER_STRICT);
+  JsonPointer root(
+      json_tokener_parse_ex(tokener.get(), payload.data(),
+                            static_cast<int>(payload.size())),
+      &json_object_put);
+  const json_tokener_error parse_error =
+      json_tokener_get_error(tokener.get());
+  if (!root || parse_error != json_tokener_success ||
+      json_object_get_type(root.get()) != json_type_object) {
+    if (error != nullptr) {
+      *error = "invalid runtime status in " + path;
+    }
+    return false;
+  }
+
+  RuntimeStatus parsed;
+  if (!ReadInt64(root.get(), "pid", &parsed.pid) ||
+      !ReadInt64(root.get(), "startedAt", &parsed.started_at) ||
+      !ReadString(root.get(), "state", &parsed.state) ||
+      !ReadString(root.get(), "endpoint", &parsed.endpoint) ||
+      !ReadString(root.get(), "version", &parsed.version) ||
+      parsed.pid <= 0) {
+    if (error != nullptr) {
+      *error = "runtime status is missing required fields";
+    }
+    return false;
+  }
+
+  *status = parsed;
+  return true;
+}
+
+bool RemoveRuntimeStatus(const std::string& cache_directory,
+                         std::string* error) {
+  const std::string path = StatusFilePath(cache_directory);
+  std::error_code filesystem_error;
+  const bool removed = std::filesystem::remove(path, filesystem_error);
+  if (filesystem_error) {
+    if (error != nullptr) {
+      *error = filesystem_error.message();
+    }
+    return false;
+  }
+
+  const bool exists = std::filesystem::exists(path, filesystem_error);
+  if (filesystem_error) {
+    if (error != nullptr) {
+      *error = filesystem_error.message();
+    }
+    return false;
+  }
+  return removed || !exists;
+}
+
+bool ProcessExists(int64_t pid) {
+  if (pid <= 0) {
+    return false;
+  }
+  if (kill(static_cast<pid_t>(pid), 0) == 0) {
+    return true;
+  }
+  return errno == EPERM;
+}
+
+bool IsDefyxCliProcess(int64_t pid) {
+  if (!ProcessExists(pid)) {
+    return false;
+  }
+
+  const auto executable_path = [](int64_t process_id) {
+    const std::string proc_path =
+        "/proc/" + std::to_string(static_cast<long long>(process_id)) + "/exe";
+    char executable[4096];
+    const ssize_t length =
+        readlink(proc_path.c_str(), executable, sizeof(executable) - 1);
+    if (length <= 0) {
+      return std::string();
+    }
+    executable[length] = '\0';
+    return std::string(executable);
+  };
+
+  const std::string executable = executable_path(pid);
+  if (executable.empty()) {
+    return false;
+  }
+
+  const std::string current_executable =
+      executable_path(static_cast<int64_t>(getpid()));
+  if (!current_executable.empty() && executable == current_executable) {
+    return true;
+  }
+
+  const std::string name = std::filesystem::path(executable).filename().string();
+  return name == "defyxvpn-cli" ||
+         name.rfind("defyxvpn-cli-", 0) == 0;
+}
+
+}  // namespace defyx_cli

--- a/linux/cli/src/status_file.h
+++ b/linux/cli/src/status_file.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace defyx_cli {
+
+struct RuntimeStatus {
+  int64_t pid = 0;
+  int64_t started_at = 0;
+  std::string state;
+  std::string endpoint;
+  std::string version;
+};
+
+class InstanceLock {
+ public:
+  InstanceLock() = default;
+  ~InstanceLock();
+
+  InstanceLock(const InstanceLock&) = delete;
+  InstanceLock& operator=(const InstanceLock&) = delete;
+
+  bool Acquire(const std::string& cache_directory, std::string* error);
+  bool acquired() const { return file_descriptor_ >= 0; }
+
+ private:
+  int file_descriptor_ = -1;
+};
+
+std::string StatusFilePath(const std::string& cache_directory);
+bool EnsurePrivateDirectory(const std::string& directory, std::string* error);
+bool WriteRuntimeStatus(const std::string& cache_directory,
+                        const RuntimeStatus& status, std::string* error);
+bool ReadRuntimeStatus(const std::string& cache_directory,
+                       RuntimeStatus* status, std::string* error);
+bool RemoveRuntimeStatus(const std::string& cache_directory,
+                         std::string* error);
+bool ProcessExists(int64_t pid);
+bool IsDefyxCliProcess(int64_t pid);
+
+}  // namespace defyx_cli

--- a/linux/cli/src/tcp_forwarder.cpp
+++ b/linux/cli/src/tcp_forwarder.cpp
@@ -286,8 +286,16 @@ void TcpForwarder::ForwardConnection(int client_socket) {
       {client_socket, POLLIN, 0},
       {target_socket, POLLIN, 0},
   };
+  bool read_open[2] = {true, true};
 
-  while (!stopping_.load()) {
+  // A FIN closes one direction only; let the peer drain the other direction.
+  const auto finish_read_direction = [&sockets, &read_open](size_t index) {
+    read_open[index] = false;
+    sockets[index].events = 0;
+    shutdown(sockets[1U - index].fd, SHUT_WR);
+  };
+
+  while (!stopping_.load() && (read_open[0] || read_open[1])) {
     const int result = poll(sockets, 2, 500);
     if (result < 0) {
       if (errno == EINTR) {
@@ -301,20 +309,38 @@ void TcpForwarder::ForwardConnection(int client_socket) {
 
     bool relay_failed = false;
     for (size_t index = 0; index < 2; ++index) {
+      if (!read_open[index]) {
+        continue;
+      }
       const short events = sockets[index].revents;
       if ((events & POLLIN) != 0) {
-        const ssize_t received =
-            recv(sockets[index].fd, buffer.data(), buffer.size(), 0);
+        ssize_t received = 0;
+        do {
+          received =
+              recv(sockets[index].fd, buffer.data(), buffer.size(), 0);
+        } while (received < 0 && errno == EINTR);
+
         const int destination = sockets[1U - index].fd;
-        if (received <= 0 ||
+        if (received > 0 &&
             !SendAll(destination, buffer.data(),
                      static_cast<size_t>(received))) {
           relay_failed = true;
           break;
         }
+        if (received == 0) {
+          finish_read_direction(index);
+        } else if (received < 0) {
+          relay_failed = true;
+          break;
+        }
       }
-      if ((events & (POLLERR | POLLHUP | POLLNVAL)) != 0 &&
-          (events & POLLIN) == 0) {
+      if (!read_open[index]) {
+        continue;
+      }
+      if ((events & POLLHUP) != 0 && (events & POLLIN) == 0) {
+        finish_read_direction(index);
+      } else if ((events & (POLLERR | POLLNVAL)) != 0 &&
+                 (events & POLLIN) == 0) {
         relay_failed = true;
         break;
       }

--- a/linux/cli/src/tcp_forwarder.cpp
+++ b/linux/cli/src/tcp_forwarder.cpp
@@ -1,0 +1,402 @@
+#include "tcp_forwarder.h"
+
+#include <array>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <system_error>
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace defyx_cli {
+
+namespace {
+
+constexpr size_t kRelayBufferSize = 32U * 1024U;
+constexpr size_t kMaximumConnections = 256U;
+
+std::string SocketError(const std::string& operation) {
+  return operation + ": " + std::strerror(errno);
+}
+
+bool MakeSocketAddress(const std::string& address, uint16_t port,
+                       sockaddr_storage* storage, socklen_t* length,
+                       int* family) {
+  std::memset(storage, 0, sizeof(*storage));
+
+  auto* ipv4 = reinterpret_cast<sockaddr_in*>(storage);
+  if (inet_pton(AF_INET, address.c_str(), &ipv4->sin_addr) == 1) {
+    ipv4->sin_family = AF_INET;
+    ipv4->sin_port = htons(port);
+    *length = sizeof(*ipv4);
+    *family = AF_INET;
+    return true;
+  }
+
+  auto* ipv6 = reinterpret_cast<sockaddr_in6*>(storage);
+  if (inet_pton(AF_INET6, address.c_str(), &ipv6->sin6_addr) == 1) {
+    ipv6->sin6_family = AF_INET6;
+    ipv6->sin6_port = htons(port);
+    *length = sizeof(*ipv6);
+    *family = AF_INET6;
+    return true;
+  }
+  return false;
+}
+
+void SetCloseOnExec(int socket) {
+  const int flags = fcntl(socket, F_GETFD);
+  if (flags >= 0) {
+    fcntl(socket, F_SETFD, flags | FD_CLOEXEC);
+  }
+}
+
+bool SendAll(int socket, const char* data, size_t size) {
+  size_t sent = 0;
+  while (sent < size) {
+    const ssize_t result =
+        send(socket, data + sent, size - sent, MSG_NOSIGNAL);
+    if (result > 0) {
+      sent += static_cast<size_t>(result);
+      continue;
+    }
+    if (result < 0 && errno == EINTR) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+TcpForwarder::~TcpForwarder() {
+  Stop();
+}
+
+bool TcpForwarder::Start(const std::string& listen_address,
+                         uint16_t listen_port,
+                         const std::string& target_address,
+                         uint16_t target_port, std::string* error) {
+  if (running()) {
+    if (error != nullptr) {
+      *error = "TCP forwarder is already running";
+    }
+    return false;
+  }
+
+  sockaddr_storage listen_storage {};
+  socklen_t listen_length = 0;
+  int listen_family = 0;
+  if (!MakeSocketAddress(listen_address, listen_port, &listen_storage,
+                         &listen_length, &listen_family)) {
+    if (error != nullptr) {
+      *error = "listen address must be a literal IPv4 or IPv6 address";
+    }
+    return false;
+  }
+
+  sockaddr_storage target_storage {};
+  socklen_t target_length = 0;
+  int target_family = 0;
+  if (!MakeSocketAddress(target_address, target_port, &target_storage,
+                         &target_length, &target_family)) {
+    if (error != nullptr) {
+      *error = "target address must be a literal IPv4 or IPv6 address";
+    }
+    return false;
+  }
+
+  const int listener = socket(listen_family, SOCK_STREAM, IPPROTO_TCP);
+  if (listener < 0) {
+    if (error != nullptr) {
+      *error = SocketError("cannot create listener");
+    }
+    return false;
+  }
+  SetCloseOnExec(listener);
+
+  int enabled = 1;
+  setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, &enabled, sizeof(enabled));
+  if (listen_family == AF_INET6) {
+    setsockopt(listener, IPPROTO_IPV6, IPV6_V6ONLY, &enabled, sizeof(enabled));
+  }
+
+  if (bind(listener, reinterpret_cast<const sockaddr*>(&listen_storage),
+           listen_length) != 0) {
+    if (error != nullptr) {
+      *error = SocketError("cannot bind " +
+                           FormatSocksEndpoint(listen_address, listen_port));
+    }
+    close(listener);
+    return false;
+  }
+  if (listen(listener, SOMAXCONN) != 0) {
+    if (error != nullptr) {
+      *error = SocketError("cannot listen on " +
+                           FormatSocksEndpoint(listen_address, listen_port));
+    }
+    close(listener);
+    return false;
+  }
+
+  sockaddr_storage bound_storage {};
+  socklen_t bound_length = sizeof(bound_storage);
+  if (getsockname(listener, reinterpret_cast<sockaddr*>(&bound_storage),
+                  &bound_length) != 0) {
+    if (error != nullptr) {
+      *error = SocketError("cannot inspect listener");
+    }
+    close(listener);
+    return false;
+  }
+
+  if (bound_storage.ss_family == AF_INET) {
+    const auto* ipv4 =
+        reinterpret_cast<const sockaddr_in*>(&bound_storage);
+    listen_port_ = ntohs(ipv4->sin_port);
+  } else {
+    const auto* ipv6 =
+        reinterpret_cast<const sockaddr_in6*>(&bound_storage);
+    listen_port_ = ntohs(ipv6->sin6_port);
+  }
+
+  target_address_ = target_address;
+  target_port_ = target_port;
+  stopping_.store(false);
+  listen_socket_ = listener;
+  try {
+    accept_thread_ =
+        std::thread([this, listener]() { AcceptLoop(listener); });
+  } catch (const std::system_error& exception) {
+    listen_socket_ = -1;
+    close(listener);
+    if (error != nullptr) {
+      *error = "cannot start listener thread: " +
+               std::string(exception.what());
+    }
+    return false;
+  }
+  return true;
+}
+
+void TcpForwarder::Stop() {
+  stopping_.store(true);
+
+  const int listener = listen_socket_;
+  listen_socket_ = -1;
+  if (listener >= 0) {
+    shutdown(listener, SHUT_RDWR);
+    close(listener);
+  }
+  if (accept_thread_.joinable()) {
+    accept_thread_.join();
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(sockets_mutex_);
+    for (const int socket : active_sockets_) {
+      shutdown(socket, SHUT_RDWR);
+    }
+  }
+  {
+    std::unique_lock<std::mutex> lock(workers_mutex_);
+    workers_finished_.wait(
+        lock, [this]() { return active_workers_ == 0; });
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(sockets_mutex_);
+    active_sockets_.clear();
+  }
+  listen_port_ = 0;
+  target_address_.clear();
+  target_port_ = 0;
+}
+
+void TcpForwarder::AcceptLoop(int listener) {
+  while (!stopping_.load()) {
+    const int client = accept(listener, nullptr, nullptr);
+    if (client < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      if (stopping_.load() || errno == EBADF || errno == EINVAL) {
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      continue;
+    }
+    SetCloseOnExec(client);
+    if (stopping_.load()) {
+      close(client);
+      break;
+    }
+
+    TrackSocket(client);
+    bool at_capacity = false;
+    {
+      std::lock_guard<std::mutex> lock(workers_mutex_);
+      if (active_workers_ >= kMaximumConnections) {
+        at_capacity = true;
+      } else {
+        ++active_workers_;
+      }
+    }
+    if (at_capacity) {
+      CloseTrackedSocket(client);
+      continue;
+    }
+    try {
+      std::thread([this, client]() {
+        ForwardConnection(client);
+        {
+          std::lock_guard<std::mutex> lock(workers_mutex_);
+          --active_workers_;
+        }
+        workers_finished_.notify_all();
+      }).detach();
+    } catch (const std::system_error&) {
+      {
+        std::lock_guard<std::mutex> lock(workers_mutex_);
+        --active_workers_;
+      }
+      CloseTrackedSocket(client);
+      workers_finished_.notify_all();
+    }
+  }
+}
+
+void TcpForwarder::ForwardConnection(int client_socket) {
+  const int target_socket = ConnectTarget();
+  if (target_socket < 0) {
+    CloseTrackedSocket(client_socket);
+    return;
+  }
+  TrackSocket(target_socket);
+
+  std::array<char, kRelayBufferSize> buffer {};
+  pollfd sockets[2] = {
+      {client_socket, POLLIN, 0},
+      {target_socket, POLLIN, 0},
+  };
+
+  while (!stopping_.load()) {
+    const int result = poll(sockets, 2, 500);
+    if (result < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      break;
+    }
+    if (result == 0) {
+      continue;
+    }
+
+    bool relay_failed = false;
+    for (size_t index = 0; index < 2; ++index) {
+      const short events = sockets[index].revents;
+      if ((events & POLLIN) != 0) {
+        const ssize_t received =
+            recv(sockets[index].fd, buffer.data(), buffer.size(), 0);
+        const int destination = sockets[1U - index].fd;
+        if (received <= 0 ||
+            !SendAll(destination, buffer.data(),
+                     static_cast<size_t>(received))) {
+          relay_failed = true;
+          break;
+        }
+      }
+      if ((events & (POLLERR | POLLHUP | POLLNVAL)) != 0 &&
+          (events & POLLIN) == 0) {
+        relay_failed = true;
+        break;
+      }
+    }
+    if (relay_failed) {
+      break;
+    }
+  }
+
+  CloseTrackedSocket(target_socket);
+  CloseTrackedSocket(client_socket);
+}
+
+int TcpForwarder::ConnectTarget() const {
+  sockaddr_storage storage {};
+  socklen_t length = 0;
+  int family = 0;
+  if (!MakeSocketAddress(target_address_, target_port_, &storage, &length,
+                         &family)) {
+    return -1;
+  }
+
+  const int target = socket(family, SOCK_STREAM, IPPROTO_TCP);
+  if (target < 0) {
+    return -1;
+  }
+  SetCloseOnExec(target);
+  if (connect(target, reinterpret_cast<const sockaddr*>(&storage), length) !=
+      0) {
+    close(target);
+    return -1;
+  }
+  return target;
+}
+
+void TcpForwarder::TrackSocket(int socket) {
+  std::lock_guard<std::mutex> lock(sockets_mutex_);
+  active_sockets_.insert(socket);
+}
+
+void TcpForwarder::CloseTrackedSocket(int socket) {
+  {
+    std::lock_guard<std::mutex> lock(sockets_mutex_);
+    active_sockets_.erase(socket);
+  }
+  shutdown(socket, SHUT_RDWR);
+  close(socket);
+}
+
+bool IsIpAddress(const std::string& address) {
+  sockaddr_storage storage {};
+  socklen_t length = 0;
+  int family = 0;
+  return MakeSocketAddress(address, 1, &storage, &length, &family);
+}
+
+bool IsLoopbackAddress(const std::string& address) {
+  in_addr ipv4 {};
+  if (inet_pton(AF_INET, address.c_str(), &ipv4) == 1) {
+    return (ntohl(ipv4.s_addr) >> 24U) == 127U;
+  }
+
+  in6_addr ipv6 {};
+  return inet_pton(AF_INET6, address.c_str(), &ipv6) == 1 &&
+         IN6_IS_ADDR_LOOPBACK(&ipv6);
+}
+
+bool IsWildcardAddress(const std::string& address) {
+  in_addr ipv4 {};
+  if (inet_pton(AF_INET, address.c_str(), &ipv4) == 1) {
+    return ipv4.s_addr == htonl(INADDR_ANY);
+  }
+
+  in6_addr ipv6 {};
+  return inet_pton(AF_INET6, address.c_str(), &ipv6) == 1 &&
+         IN6_IS_ADDR_UNSPECIFIED(&ipv6);
+}
+
+std::string FormatSocksEndpoint(const std::string& address, uint16_t port) {
+  const bool is_ipv6 = address.find(':') != std::string::npos;
+  return "socks5h://" + (is_ipv6 ? "[" + address + "]" : address) + ":" +
+         std::to_string(port);
+}
+
+}  // namespace defyx_cli

--- a/linux/cli/src/tcp_forwarder.h
+++ b/linux/cli/src/tcp_forwarder.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_set>
+
+namespace defyx_cli {
+
+class TcpForwarder {
+ public:
+  TcpForwarder() = default;
+  ~TcpForwarder();
+
+  TcpForwarder(const TcpForwarder&) = delete;
+  TcpForwarder& operator=(const TcpForwarder&) = delete;
+
+  bool Start(const std::string& listen_address, uint16_t listen_port,
+             const std::string& target_address, uint16_t target_port,
+             std::string* error);
+  void Stop();
+
+  bool running() const { return listen_socket_ >= 0; }
+  uint16_t listen_port() const { return listen_port_; }
+
+ private:
+  void AcceptLoop(int listener);
+  void ForwardConnection(int client_socket);
+  int ConnectTarget() const;
+  void TrackSocket(int socket);
+  void CloseTrackedSocket(int socket);
+
+  int listen_socket_ = -1;
+  uint16_t listen_port_ = 0;
+  std::string target_address_;
+  uint16_t target_port_ = 0;
+  std::atomic<bool> stopping_ {false};
+  std::thread accept_thread_;
+  std::mutex workers_mutex_;
+  std::condition_variable workers_finished_;
+  size_t active_workers_ = 0;
+  std::mutex sockets_mutex_;
+  std::unordered_set<int> active_sockets_;
+};
+
+bool IsIpAddress(const std::string& address);
+bool IsLoopbackAddress(const std::string& address);
+bool IsWildcardAddress(const std::string& address);
+std::string FormatSocksEndpoint(const std::string& address, uint16_t port);
+
+}  // namespace defyx_cli

--- a/linux/cli/tests/cli_tests.cpp
+++ b/linux/cli/tests/cli_tests.cpp
@@ -1,0 +1,318 @@
+#include "cli_options.h"
+#include "flowline.h"
+#include "progress.h"
+#include "status_file.h"
+#include "tcp_forwarder.h"
+
+#include <atomic>
+#include <cerrno>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <arpa/inet.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+namespace {
+
+int g_failures = 0;
+constexpr char kRelayMessage[] = "relay-check";
+
+void Check(bool condition, const std::string& message) {
+  if (!condition) {
+    std::cerr << "FAIL: " << message << std::endl;
+    ++g_failures;
+  }
+}
+
+bool SendAllForTest(int socket, const char* data, size_t size) {
+  size_t sent = 0;
+  while (sent < size) {
+    const ssize_t result =
+        send(socket, data + sent, size - sent, MSG_NOSIGNAL);
+    if (result > 0) {
+      sent += static_cast<size_t>(result);
+    } else if (result < 0 && errno == EINTR) {
+      continue;
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool ReceiveAllForTest(int socket, char* data, size_t size) {
+  size_t received = 0;
+  while (received < size) {
+    const ssize_t result = recv(socket, data + received, size - received, 0);
+    if (result > 0) {
+      received += static_cast<size_t>(result);
+    } else if (result < 0 && errno == EINTR) {
+      continue;
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+void TestOptions() {
+  defyx_cli::Options defaults;
+  defaults.cache_directory = "/tmp/default";
+  const defyx_cli::ParseResult result = defyx_cli::ParseOptions(
+      {"connect", "--cache-dir", "/tmp/custom", "--pattern",
+       "Warp,Psiphon", "--deep-scan", "--health-check", "--timeout", "45",
+       "--quiet"},
+      defaults);
+
+  Check(result.ok(), "valid connect options should parse");
+  Check(result.options.command == defyx_cli::Command::connect,
+        "connect command should be selected");
+  Check(result.options.cache_directory == "/tmp/custom",
+        "cache directory should be parsed");
+  Check(result.options.pattern == "Warp,Psiphon",
+        "pattern should be parsed");
+  Check(result.options.deep_scan, "deep scan should be enabled");
+  Check(result.options.health_check, "health check should be enabled");
+  Check(result.options.timeout_seconds == 45, "timeout should be parsed");
+  Check(result.options.quiet, "quiet should be enabled");
+
+  const defyx_cli::ParseResult listener = defyx_cli::ParseOptions(
+      {"connect", "--listen-address", "0.0.0.0", "--listen-port", "1080"},
+      defaults);
+  Check(listener.ok(), "custom listener options should parse");
+  Check(listener.options.listen_address == "0.0.0.0",
+        "listen address should be parsed");
+  Check(listener.options.listen_port == 1080,
+        "listen port should be parsed");
+
+  const defyx_cli::ParseResult invalid =
+      defyx_cli::ParseOptions({"connect", "--timeout", "-1"}, defaults);
+  Check(!invalid.ok(), "negative timeout should be rejected");
+
+  const defyx_cli::ParseResult invalid_address =
+      defyx_cli::ParseOptions(
+          {"connect", "--listen-address", "not-an-ip"}, defaults);
+  Check(!invalid_address.ok(), "non-IP listen address should be rejected");
+
+  const defyx_cli::ParseResult invalid_port =
+      defyx_cli::ParseOptions(
+          {"connect", "--listen-port", "65536"}, defaults);
+  Check(!invalid_port.ok(), "out-of-range listen port should be rejected");
+
+  const defyx_cli::ParseResult alias =
+      defyx_cli::ParseOptions({"stop"}, defaults);
+  Check(alias.ok() &&
+            alias.options.command == defyx_cli::Command::disconnect,
+        "stop alias should select disconnect");
+}
+
+void TestFlowLines() {
+  const defyx_cli::FlowLineResult full = defyx_cli::NormalizeFlowLine(
+      R"({"version":{},"flowLine":[{"label":"Hive","enabled":true},{"label":"Warp","enabled":false},{"label":"Outline","enabled":true}]})");
+  Check(full.ok(), "full flowline response should normalize");
+  Check(full.value ==
+            R"([{"label":"Hive","enabled":true},{"label":"Warp","enabled":false},{"label":"Outline","enabled":true}])",
+        "full response should select its flowLine array");
+  Check(full.default_pattern == "Hive,Outline",
+        "enabled labels should form the default pattern");
+
+  const defyx_cli::FlowLineResult raw = defyx_cli::NormalizeFlowLine(
+      R"({"startLine":0,"flowLine":[{"label":"Psiphon","enabled":true}]})");
+  Check(raw.ok(), "raw flowline object should normalize");
+  Check(raw.value ==
+            R"({"startLine":0,"flowLine":[{"label":"Psiphon","enabled":true}]})",
+        "raw flowline object should remain intact");
+  Check(raw.default_pattern == "Psiphon",
+        "raw object should expose its enabled label");
+
+  const defyx_cli::FlowLineResult array =
+      defyx_cli::NormalizeFlowLine(
+          R"([{"label":"Outline","enabled":true}])");
+  Check(array.ok() &&
+            array.value == R"([{"label":"Outline","enabled":true}])",
+        "raw flowline array should normalize");
+  Check(array.default_pattern == "Outline",
+        "raw array should expose its enabled label");
+
+  const defyx_cli::FlowLineResult invalid =
+      defyx_cli::NormalizeFlowLine("not-json");
+  Check(!invalid.ok(), "invalid JSON should be rejected");
+}
+
+void TestProgressEvents() {
+  Check(defyx_cli::ParseProgressEvent("Data: VPN connected") ==
+            defyx_cli::ProgressEvent::connected,
+        "connected progress should be recognized");
+  Check(defyx_cli::ParseProgressEvent("Data: VPN connecting") ==
+            defyx_cli::ProgressEvent::connecting,
+        "connecting progress should be recognized");
+  Check(defyx_cli::ParseProgressEvent("Data: VPN failed") ==
+            defyx_cli::ProgressEvent::failed,
+        "failed progress should be recognized");
+  Check(defyx_cli::ParseProgressEvent("Data: VPN cancelled") ==
+            defyx_cli::ProgressEvent::stopped,
+        "cancelled progress should be recognized");
+}
+
+void TestStatusRoundTrip() {
+  const std::filesystem::path directory =
+      std::filesystem::temp_directory_path() /
+      ("defyxvpn-cli-test-" +
+       std::to_string(static_cast<long long>(getpid())));
+
+  defyx_cli::RuntimeStatus expected;
+  expected.pid = static_cast<int64_t>(getpid());
+  expected.started_at = 123456789;
+  expected.state = "connected";
+  expected.endpoint = "socks5h://127.0.0.1:5000";
+  expected.version = "test";
+
+  std::string error;
+  Check(defyx_cli::WriteRuntimeStatus(directory.string(), expected, &error),
+        "runtime status should be written: " + error);
+
+  defyx_cli::RuntimeStatus actual;
+  error.clear();
+  Check(defyx_cli::ReadRuntimeStatus(directory.string(), &actual, &error),
+        "runtime status should be read: " + error);
+  Check(actual.pid == expected.pid, "status PID should round-trip");
+  Check(actual.state == expected.state, "status state should round-trip");
+  Check(actual.endpoint == expected.endpoint,
+        "status endpoint should round-trip");
+
+  error.clear();
+  Check(defyx_cli::RemoveRuntimeStatus(directory.string(), &error),
+        "runtime status should be removed: " + error);
+  std::error_code ignored;
+  std::filesystem::remove_all(directory, ignored);
+}
+
+void TestTcpForwarder() {
+  Check(defyx_cli::IsLoopbackAddress("127.0.0.1"),
+        "IPv4 loopback should be recognized");
+  Check(defyx_cli::IsWildcardAddress("0.0.0.0"),
+        "IPv4 wildcard should be recognized");
+  Check(defyx_cli::FormatSocksEndpoint("::1", 1080) ==
+            "socks5h://[::1]:1080",
+        "IPv6 endpoint should use brackets");
+
+  const int echo_listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (echo_listener < 0) {
+    Check(false, "echo listener socket should be created");
+    return;
+  }
+
+  sockaddr_in echo_address {};
+  echo_address.sin_family = AF_INET;
+  echo_address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  echo_address.sin_port = 0;
+  if (bind(echo_listener,
+           reinterpret_cast<const sockaddr*>(&echo_address),
+           sizeof(echo_address)) != 0 ||
+      listen(echo_listener, 1) != 0) {
+    close(echo_listener);
+    Check(false, "echo listener should bind");
+    return;
+  }
+
+  socklen_t echo_length = sizeof(echo_address);
+  if (getsockname(echo_listener,
+                  reinterpret_cast<sockaddr*>(&echo_address),
+                  &echo_length) != 0) {
+    close(echo_listener);
+    Check(false, "echo listener port should be available");
+    return;
+  }
+
+  defyx_cli::TcpForwarder forwarder;
+  std::string error;
+  if (!forwarder.Start("127.0.0.1", 0, "127.0.0.1",
+                       ntohs(echo_address.sin_port), &error)) {
+    close(echo_listener);
+    Check(false, "TCP forwarder should start: " + error);
+    return;
+  }
+
+  std::atomic<bool> echo_ok {false};
+  std::thread echo_thread([echo_listener, &echo_ok]() {
+    pollfd pending {echo_listener, POLLIN, 0};
+    if (poll(&pending, 1, 5000) <= 0) {
+      close(echo_listener);
+      return;
+    }
+
+    const int client = accept(echo_listener, nullptr, nullptr);
+    if (client >= 0) {
+      char buffer[sizeof(kRelayMessage)] {};
+      if (ReceiveAllForTest(client, buffer, sizeof(buffer)) &&
+          SendAllForTest(client, buffer, sizeof(buffer))) {
+        echo_ok.store(true);
+      }
+      close(client);
+    }
+    close(echo_listener);
+  });
+
+  const int client = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  bool relay_ok = client >= 0;
+  timeval client_timeout {};
+  client_timeout.tv_sec = 5;
+  if (client >= 0) {
+    setsockopt(client, SOL_SOCKET, SO_RCVTIMEO, &client_timeout,
+               sizeof(client_timeout));
+  }
+  sockaddr_in forwarder_address {};
+  forwarder_address.sin_family = AF_INET;
+  forwarder_address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  forwarder_address.sin_port = htons(forwarder.listen_port());
+
+  if (relay_ok &&
+      connect(client, reinterpret_cast<const sockaddr*>(&forwarder_address),
+              sizeof(forwarder_address)) != 0) {
+    relay_ok = false;
+  }
+
+  if (relay_ok &&
+      !SendAllForTest(client, kRelayMessage, sizeof(kRelayMessage))) {
+    relay_ok = false;
+  }
+
+  char response[sizeof(kRelayMessage)] {};
+  if (relay_ok) {
+    relay_ok = ReceiveAllForTest(client, response, sizeof(response)) &&
+               std::memcmp(response, kRelayMessage,
+                           sizeof(kRelayMessage)) == 0;
+  }
+  if (client >= 0) {
+    close(client);
+  }
+
+  forwarder.Stop();
+  echo_thread.join();
+  Check(relay_ok && echo_ok.load(),
+        "TCP forwarder should relay data in both directions");
+}
+
+}  // namespace
+
+int main() {
+  TestOptions();
+  TestFlowLines();
+  TestProgressEvents();
+  TestStatusRoundTrip();
+  TestTcpForwarder();
+
+  if (g_failures != 0) {
+    std::cerr << g_failures << " test(s) failed" << std::endl;
+    return 1;
+  }
+  std::cout << "All CLI tests passed" << std::endl;
+  return 0;
+}

--- a/linux/cli/tests/cli_tests.cpp
+++ b/linux/cli/tests/cli_tests.cpp
@@ -87,6 +87,7 @@ void TestOptions() {
        "Warp,Psiphon", "--deep-scan", "--health-check", "--timeout", "45",
        "--health-check-url", "https://example.com/check",
        "--health-check-min-bytes", "4096", "--health-check-timeout", "12",
+       "--health-check-interval", "30", "--health-check-failures", "3",
        "--quiet"},
       defaults);
 
@@ -105,6 +106,10 @@ void TestOptions() {
         "health-check minimum size should be parsed");
   Check(result.options.health_check_timeout_seconds == 12,
         "health-check timeout should be parsed");
+  Check(result.options.health_check_interval_seconds == 30,
+        "health-check interval should be parsed");
+  Check(result.options.health_check_failures == 3,
+        "health-check failure threshold should be parsed");
   Check(result.options.timeout_seconds == 45, "timeout should be parsed");
   Check(result.options.quiet, "quiet should be enabled");
 
@@ -148,6 +153,25 @@ void TestOptions() {
           {"connect", "--health-check-timeout", "0"}, defaults);
   Check(!invalid_health_timeout.ok(),
         "zero health-check timeout should be rejected");
+
+  const defyx_cli::ParseResult disabled_runtime_health =
+      defyx_cli::ParseOptions(
+          {"connect", "--health-check-interval", "0"}, defaults);
+  Check(disabled_runtime_health.ok() &&
+            disabled_runtime_health.options.health_check_interval_seconds == 0,
+        "zero runtime health-check interval should disable periodic checks");
+
+  const defyx_cli::ParseResult invalid_health_interval =
+      defyx_cli::ParseOptions(
+          {"connect", "--health-check-interval", "-1"}, defaults);
+  Check(!invalid_health_interval.ok(),
+        "negative health-check interval should be rejected");
+
+  const defyx_cli::ParseResult invalid_health_failures =
+      defyx_cli::ParseOptions(
+          {"connect", "--health-check-failures", "0"}, defaults);
+  Check(!invalid_health_failures.ok(),
+        "zero health-check failure threshold should be rejected");
 }
 
 void TestFlowLines() {

--- a/linux/cli/tests/cli_tests.cpp
+++ b/linux/cli/tests/cli_tests.cpp
@@ -62,6 +62,20 @@ bool ReceiveAllForTest(int socket, char* data, size_t size) {
   return true;
 }
 
+bool ReceiveEofForTest(int socket) {
+  char data = '\0';
+  while (true) {
+    const ssize_t result = recv(socket, &data, sizeof(data), 0);
+    if (result == 0) {
+      return true;
+    }
+    if (result < 0 && errno == EINTR) {
+      continue;
+    }
+    return false;
+  }
+}
+
 void TestOptions() {
   defyx_cli::Options defaults;
   defaults.cache_directory = "/tmp/default";
@@ -252,7 +266,8 @@ void TestTcpForwarder() {
     if (client >= 0) {
       char buffer[sizeof(kRelayMessage)] {};
       if (ReceiveAllForTest(client, buffer, sizeof(buffer)) &&
-          SendAllForTest(client, buffer, sizeof(buffer))) {
+          ReceiveEofForTest(client) &&
+          SendAllForTest(client, kRelayMessage, sizeof(kRelayMessage))) {
         echo_ok.store(true);
       }
       close(client);
@@ -283,6 +298,9 @@ void TestTcpForwarder() {
       !SendAllForTest(client, kRelayMessage, sizeof(kRelayMessage))) {
     relay_ok = false;
   }
+  if (relay_ok && shutdown(client, SHUT_WR) != 0) {
+    relay_ok = false;
+  }
 
   char response[sizeof(kRelayMessage)] {};
   if (relay_ok) {
@@ -297,7 +315,7 @@ void TestTcpForwarder() {
   forwarder.Stop();
   echo_thread.join();
   Check(relay_ok && echo_ok.load(),
-        "TCP forwarder should relay data in both directions");
+        "TCP forwarder should preserve responses after a half-close");
 }
 
 }  // namespace

--- a/linux/cli/tests/cli_tests.cpp
+++ b/linux/cli/tests/cli_tests.cpp
@@ -1,5 +1,6 @@
 #include "cli_options.h"
 #include "flowline.h"
+#include "health_check.h"
 #include "progress.h"
 #include "status_file.h"
 #include "tcp_forwarder.h"
@@ -8,6 +9,7 @@
 #include <cerrno>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <thread>
@@ -16,6 +18,7 @@
 #include <arpa/inet.h>
 #include <poll.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <unistd.h>
 
@@ -82,6 +85,8 @@ void TestOptions() {
   const defyx_cli::ParseResult result = defyx_cli::ParseOptions(
       {"connect", "--cache-dir", "/tmp/custom", "--pattern",
        "Warp,Psiphon", "--deep-scan", "--health-check", "--timeout", "45",
+       "--health-check-url", "https://example.com/check",
+       "--health-check-min-bytes", "4096", "--health-check-timeout", "12",
        "--quiet"},
       defaults);
 
@@ -94,6 +99,12 @@ void TestOptions() {
         "pattern should be parsed");
   Check(result.options.deep_scan, "deep scan should be enabled");
   Check(result.options.health_check, "health check should be enabled");
+  Check(result.options.health_check_url == "https://example.com/check",
+        "health-check URL should be parsed");
+  Check(result.options.health_check_min_bytes == 4096,
+        "health-check minimum size should be parsed");
+  Check(result.options.health_check_timeout_seconds == 12,
+        "health-check timeout should be parsed");
   Check(result.options.timeout_seconds == 45, "timeout should be parsed");
   Check(result.options.quiet, "quiet should be enabled");
 
@@ -125,6 +136,18 @@ void TestOptions() {
   Check(alias.ok() &&
             alias.options.command == defyx_cli::Command::disconnect,
         "stop alias should select disconnect");
+
+  const defyx_cli::ParseResult invalid_health_url =
+      defyx_cli::ParseOptions(
+          {"connect", "--health-check-url", "http://example.com"}, defaults);
+  Check(!invalid_health_url.ok(),
+        "non-HTTPS health-check URL should be rejected");
+
+  const defyx_cli::ParseResult invalid_health_timeout =
+      defyx_cli::ParseOptions(
+          {"connect", "--health-check-timeout", "0"}, defaults);
+  Check(!invalid_health_timeout.ok(),
+        "zero health-check timeout should be rejected");
 }
 
 void TestFlowLines() {
@@ -173,6 +196,60 @@ void TestProgressEvents() {
   Check(defyx_cli::ParseProgressEvent("Data: VPN cancelled") ==
             defyx_cli::ProgressEvent::stopped,
         "cancelled progress should be recognized");
+}
+
+void TestHealthCheck() {
+  const std::vector<std::string> methods =
+      defyx_cli::SplitConnectionMethods(
+          " Hive, Xray, Hive, ,Outline ");
+  Check(methods ==
+            std::vector<std::string>({"Hive", "Xray", "Outline"}),
+        "connection methods should be trimmed and deduplicated");
+
+  const std::filesystem::path directory =
+      std::filesystem::temp_directory_path() /
+      ("defyxvpn-health-test-" +
+       std::to_string(static_cast<long long>(getpid())));
+  std::error_code filesystem_error;
+  std::filesystem::create_directories(directory, filesystem_error);
+  const std::filesystem::path fake_curl = directory / "curl";
+
+  {
+    std::ofstream script(fake_curl);
+    script << "#!/bin/sh\nprintf '200 65536\\n'\n";
+  }
+  chmod(fake_curl.c_str(), 0700);
+
+  defyx_cli::HealthCheckSettings settings;
+  settings.url = "https://example.com/check";
+  settings.minimum_bytes = 65536;
+  settings.timeout_seconds = 2;
+  settings.curl_executable = fake_curl.string();
+
+  const defyx_cli::HealthCheckResult healthy =
+      defyx_cli::RunHttpsHealthCheck(settings);
+  Check(healthy.healthy, "complete HTTPS transfer should pass health check");
+  Check(healthy.http_status == 200,
+        "health check should capture HTTP status");
+  Check(healthy.downloaded_bytes == 65536,
+        "health check should capture transfer size");
+
+  {
+    std::ofstream script(fake_curl, std::ios::trunc);
+    script << "#!/bin/sh\nprintf '200 1024\\n'\nexit 18\n";
+  }
+  chmod(fake_curl.c_str(), 0700);
+
+  const defyx_cli::HealthCheckResult truncated =
+      defyx_cli::RunHttpsHealthCheck(settings);
+  Check(!truncated.healthy,
+        "truncated HTTPS transfer should fail health check");
+  Check(truncated.exit_code == 18,
+        "health check should preserve curl's partial-transfer exit code");
+  Check(truncated.downloaded_bytes == 1024,
+        "failed health check should preserve downloaded byte count");
+
+  std::filesystem::remove_all(directory, filesystem_error);
 }
 
 void TestStatusRoundTrip() {
@@ -324,6 +401,7 @@ int main() {
   TestOptions();
   TestFlowLines();
   TestProgressEvents();
+  TestHealthCheck();
   TestStatusRoundTrip();
   TestTcpForwarder();
 

--- a/linux/cli/tests/integration_test.sh
+++ b/linux/cli/tests/integration_test.sh
@@ -125,3 +125,64 @@ connect_pid=""
 grep -q "health check failed for Bad" "$health_log"
 grep -q "Health check passed for Mock" "$health_log"
 grep -q "Trying the next connection method" "$health_log"
+
+health_count="$runtime_dir/health-count"
+runtime_health_log="$runtime_dir/runtime-health.log"
+cat >"$fake_bin/curl" <<'EOF'
+#!/usr/bin/env bash
+count=0
+if [[ -f "$MOCK_HEALTH_COUNT_FILE" ]]; then
+  read -r count <"$MOCK_HEALTH_COUNT_FILE"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$MOCK_HEALTH_COUNT_FILE"
+if (( count == 1 )); then
+  printf '200 65536\n'
+  exit 0
+fi
+printf '000 0\n'
+exit 28
+EOF
+chmod +x "$fake_bin/curl"
+
+PATH="$fake_bin:$PATH" MOCK_HEALTH_COUNT_FILE="$health_count" \
+  "$managed_cli" connect \
+    --core-lib "$core" \
+    --cache-dir "$runtime_dir" \
+    --pattern "Mock" \
+    --listen-address 127.0.0.1 \
+    --listen-port 18080 \
+    --health-check \
+    --health-check-url https://example.com/check \
+    --health-check-interval 1 \
+    --health-check-failures 2 \
+    --timeout 5 >"$runtime_health_log" 2>&1 &
+connect_pid="$!"
+
+for _ in $(seq 1 80); do
+  if ! kill -0 "$connect_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if kill -0 "$connect_pid" 2>/dev/null; then
+  cat "$runtime_health_log"
+  echo "runtime health monitor did not stop the unhealthy connection" >&2
+  exit 1
+fi
+
+set +e
+wait "$connect_pid"
+runtime_health_status="$?"
+set -e
+connect_pid=""
+
+if [[ "$runtime_health_status" -ne 4 ]]; then
+  cat "$runtime_health_log"
+  echo "runtime health failure returned $runtime_health_status, expected 4" >&2
+  exit 1
+fi
+grep -q "runtime health check failed for Mock (1/2)" "$runtime_health_log"
+grep -q "runtime health check failed for Mock (2/2)" "$runtime_health_log"
+grep -q "failed 2 consecutive runtime health checks" "$runtime_health_log"

--- a/linux/cli/tests/integration_test.sh
+++ b/linux/cli/tests/integration_test.sh
@@ -70,3 +70,58 @@ if [[ -e "$runtime_dir/defyxvpn-cli.status.json" ]]; then
   echo "runtime status was not cleaned up" >&2
   exit 1
 fi
+
+fake_bin="$runtime_dir/bin"
+method_file="$runtime_dir/current-method"
+health_log="$runtime_dir/health-connect.log"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/curl" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$(cat "$MOCK_DXCORE_METHOD_FILE")" == "Bad" ]]; then
+  printf '200 1024\n'
+  exit 18
+fi
+printf '200 65536\n'
+EOF
+chmod +x "$fake_bin/curl"
+
+PATH="$fake_bin:$PATH" MOCK_DXCORE_METHOD_FILE="$method_file" \
+  "$managed_cli" connect \
+    --core-lib "$core" \
+    --cache-dir "$runtime_dir" \
+    --pattern "Bad,Mock" \
+    --listen-address 127.0.0.1 \
+    --listen-port 18080 \
+    --health-check \
+    --health-check-url https://example.com/check \
+    --timeout 5 >"$health_log" 2>&1 &
+connect_pid="$!"
+
+connected=false
+for _ in $(seq 1 50); do
+  if "$managed_cli" status --cache-dir "$runtime_dir" 2>/dev/null |
+      grep -q "State:    connected"; then
+    connected=true
+    break
+  fi
+  if ! kill -0 "$connect_pid" 2>/dev/null; then
+    cat "$health_log"
+    echo "health-check process exited before failover connected" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+
+if [[ "$connected" != true ]]; then
+  cat "$health_log"
+  echo "health-check failover did not become ready" >&2
+  exit 1
+fi
+
+"$managed_cli" disconnect --cache-dir "$runtime_dir"
+wait "$connect_pid"
+connect_pid=""
+
+grep -q "health check failed for Bad" "$health_log"
+grep -q "Health check passed for Mock" "$health_log"
+grep -q "Trying the next connection method" "$health_log"

--- a/linux/cli/tests/integration_test.sh
+++ b/linux/cli/tests/integration_test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cli="$1"
+core="$2"
+runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/defyxvpn-cli-integration.XXXXXX")"
+log_file="$runtime_dir/connect.log"
+managed_cli="$runtime_dir/server-vpn"
+connect_pid=""
+
+cleanup() {
+  if [[ -n "$connect_pid" ]] && kill -0 "$connect_pid" 2>/dev/null; then
+    kill -TERM "$connect_pid" 2>/dev/null || true
+    wait "$connect_pid" 2>/dev/null || true
+  fi
+  rm -rf "$runtime_dir"
+}
+trap cleanup EXIT
+
+cp "$cli" "$managed_cli"
+
+if "$managed_cli" connect \
+    --core-lib "$core" \
+    --cache-dir "$runtime_dir" \
+    --listen-address 0.0.0.0 \
+    --listen-port 5000 >"$runtime_dir/conflict.log" 2>&1; then
+  echo "wildcard port 5000 should have been rejected" >&2
+  exit 1
+fi
+grep -q "conflicts with DXcore's internal" "$runtime_dir/conflict.log"
+
+"$managed_cli" connect \
+  --core-lib "$core" \
+  --cache-dir "$runtime_dir" \
+  --listen-address 127.0.0.1 \
+  --listen-port 18080 \
+  --timeout 5 >"$log_file" 2>&1 &
+connect_pid="$!"
+
+connected=false
+for _ in $(seq 1 50); do
+  if "$managed_cli" status --cache-dir "$runtime_dir" 2>/dev/null |
+      grep -q "State:    connected"; then
+    connected=true
+    break
+  fi
+  if ! kill -0 "$connect_pid" 2>/dev/null; then
+    cat "$log_file"
+    echo "connect process exited before reaching connected state" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+
+if [[ "$connected" != true ]]; then
+  cat "$log_file"
+  echo "connection did not become ready" >&2
+  exit 1
+fi
+
+"$managed_cli" status --cache-dir "$runtime_dir" |
+  grep -q "Endpoint: socks5h://127.0.0.1:18080"
+"$managed_cli" disconnect --cache-dir "$runtime_dir"
+wait "$connect_pid"
+connect_pid=""
+
+grep -q "Connected. SOCKS5 proxy:" "$log_file"
+grep -q "Using enabled connection methods: Mock" "$log_file"
+if [[ -e "$runtime_dir/defyxvpn-cli.status.json" ]]; then
+  echo "runtime status was not cleaned up" >&2
+  exit 1
+fi

--- a/linux/cli/tests/mock_dxcore.c
+++ b/linux/cli/tests/mock_dxcore.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 
 typedef void (*progress_callback)(char*);
@@ -22,11 +23,21 @@ int StartVPN(const char* cache_dir, const char* flow_line, const char* pattern,
   (void)deep_scan;
   (void)health_check;
 
-  if (pattern == NULL || strcmp(pattern, "Mock") != 0) {
+  if (pattern == NULL ||
+      (strcmp(pattern, "Mock") != 0 && strcmp(pattern, "Bad") != 0)) {
     if (current_callback != NULL) {
       current_callback("Data: VPN failed");
     }
     return 0;
+  }
+
+  const char* method_file = getenv("MOCK_DXCORE_METHOD_FILE");
+  if (method_file != NULL) {
+    FILE* stream = fopen(method_file, "w");
+    if (stream != NULL) {
+      fputs(pattern, stream);
+      fclose(stream);
+    }
   }
 
   if (current_callback != NULL) {

--- a/linux/cli/tests/mock_dxcore.c
+++ b/linux/cli/tests/mock_dxcore.c
@@ -1,0 +1,111 @@
+#include <stdlib.h>
+#include <string.h>
+
+typedef void (*progress_callback)(char*);
+
+static progress_callback current_callback = NULL;
+static int connected = 0;
+
+static char* CopyString(const char* value) {
+  const size_t length = strlen(value) + 1;
+  char* copy = (char*)malloc(length);
+  if (copy != NULL) {
+    memcpy(copy, value, length);
+  }
+  return copy;
+}
+
+int StartVPN(const char* cache_dir, const char* flow_line, const char* pattern,
+             int deep_scan, int health_check) {
+  (void)cache_dir;
+  (void)flow_line;
+  (void)deep_scan;
+  (void)health_check;
+
+  if (pattern == NULL || strcmp(pattern, "Mock") != 0) {
+    if (current_callback != NULL) {
+      current_callback("Data: VPN failed");
+    }
+    return 0;
+  }
+
+  if (current_callback != NULL) {
+    current_callback("Data: VPN connecting");
+    current_callback("Data: Config label: Mock");
+  }
+  connected = 1;
+  if (current_callback != NULL) {
+    current_callback("Data: VPN connected");
+  }
+  return 1;
+}
+
+int StopVPN(void) {
+  connected = 0;
+  if (current_callback != NULL) {
+    current_callback("Data: VPN stopped");
+  }
+  return 1;
+}
+
+void Stop(void) {
+  connected = 0;
+}
+
+long long MeasurePing(void) {
+  return 42;
+}
+
+char* GetFlag(void) {
+  return CopyString("xx");
+}
+
+void SetAsnName(void) {}
+
+void SetTimeZone(float time_zone) {
+  (void)time_zone;
+}
+
+char* GetFlowLine(int is_test) {
+  (void)is_test;
+  return CopyString(
+      "{\"version\":{},\"flowLine\":"
+      "[{\"label\":\"Mock\",\"enabled\":true}]}");
+}
+
+char* GetCachedFlowLine(void) {
+  return GetFlowLine(0);
+}
+
+char* DecodeAndVerifyFlowline(const char* flow_line) {
+  (void)flow_line;
+  return CopyString("");
+}
+
+char* GetVpnStatus(void) {
+  return CopyString(connected ? "connected" : "disconnected");
+}
+
+void SetProgressCallback(progress_callback callback) {
+  current_callback = callback;
+}
+
+void SetVerboseLogging(int enabled) {
+  (void)enabled;
+}
+
+void FreeString(char* value) {
+  free(value);
+}
+
+void SetConnectionMethod(const char* method) {
+  (void)method;
+}
+
+void SetCacheDir(const char* cache_dir) {
+  (void)cache_dir;
+}
+
+int IsTunnelRunning(void) {
+  return connected;
+}

--- a/linux/runner/defyx_core.cpp
+++ b/linux/runner/defyx_core.cpp
@@ -34,6 +34,9 @@ typedef int (*dx_is_tunnel_running_fn)();
 
 static void* g_dx_dll = nullptr;
 static std::mutex g_dx_mutex;
+static std::mutex g_error_mutex;
+static std::mutex g_progress_mutex;
+static std::string g_last_error;
 static dx_start_vpn_fn g_start_vpn = nullptr;
 static dx_stop_vpn_fn g_stop_vpn = nullptr;
 static dx_start_t2s_fn g_start_t2s = nullptr;
@@ -53,6 +56,11 @@ static dx_free_string_fn g_free_string = nullptr;
 static dx_set_connection_method_fn g_set_connection_method = nullptr;
 static dx_set_cache_dir_fn g_set_cache_dir = nullptr;
 static dx_is_tunnel_running_fn g_is_tunnel_running = nullptr;
+
+static void SetLastError(const std::string& error) {
+  std::lock_guard<std::mutex> lock(g_error_mutex);
+  g_last_error = error;
+}
 
 // Helper: get directory of current executable
 static std::string GetExeDir() {
@@ -81,19 +89,44 @@ static void DxProgressC(char* msg) {
   if (!msg) return;
   std::string s(msg);
   defyx_core::LogMessage("[DX] " + s);
-  if (g_progress_handler) g_progress_handler(s);
+  std::function<void(std::string)> handler;
+  {
+    std::lock_guard<std::mutex> lock(g_progress_mutex);
+    handler = g_progress_handler;
+  }
+  if (handler) handler(s);
 }
 
 bool LoadCoreDll(const std::string& dllPath) {
   std::lock_guard<std::mutex> lock(g_dx_mutex);
-  if (g_dx_dll) return true;
+  if (g_dx_dll) {
+    SetLastError("");
+    return true;
+  }
 
   std::string path = dllPath;
   void* dll = nullptr;
 
-  // 1) Prefer loading from the exe directory
+  // An explicit path is authoritative. This keeps service configurations
+  // deterministic when multiple DXcore versions are installed.
+  if (!path.empty()) {
+    dll = dlopen(path.c_str(), RTLD_LAZY);
+    if (!dll) {
+      const char* err = dlerror();
+      const std::string message =
+          "dlopen(" + path + ") failed: " +
+          (err ? std::string(err) : "unknown");
+      defyx_core::LogMessage(message);
+      SetLastError(message);
+      return false;
+    }
+    defyx_core::LogMessage("Loaded libdxcore_amd64.so from provided path: " +
+                           path);
+  }
+
+  // Otherwise, prefer loading from the executable directory.
   std::string exeDir = GetExeDir();
-  if (!exeDir.empty()) {
+  if (!dll && !exeDir.empty()) {
     std::string full = exeDir + "libdxcore_amd64.so";
     dll = dlopen(full.c_str(), RTLD_LAZY);
     if (!dll) {
@@ -104,7 +137,7 @@ bool LoadCoreDll(const std::string& dllPath) {
     }
   }
 
-  // 1b) If not in exe dir root, look in lib/ next to the executable (Flutter bundle layout)
+  // If not in the executable root, look in lib/ next to it.
   if (!dll && !exeDir.empty()) {
     std::string nested = exeDir + "lib/libdxcore_amd64.so";
     dll = dlopen(nested.c_str(), RTLD_LAZY);
@@ -116,23 +149,16 @@ bool LoadCoreDll(const std::string& dllPath) {
     }
   }
 
-  // 2) If caller provided a non-empty path and we didn't load yet, try it explicitly
-  if (!dll && !path.empty()) {
-    dll = dlopen(path.c_str(), RTLD_LAZY);
-    if (!dll) {
-      const char* err = dlerror();
-      defyx_core::LogMessage("dlopen failed for provided path '" + path + "' err=" + (err ? std::string(err) : "unknown"));
-    } else {
-      defyx_core::LogMessage("Loaded libdxcore_amd64.so from provided path: " + path);
-    }
-  }
-
-  // 3) As a last resort, attempt to load libdxcore_amd64.so using the default search path
+  // As a last resort, use the dynamic loader's default search path.
   if (!dll) {
     dll = dlopen("libdxcore_amd64.so", RTLD_LAZY);
     if (!dll) {
       const char* err = dlerror();
-      defyx_core::LogMessage("Final dlopen('libdxcore_amd64.so') failed err=" + (err ? std::string(err) : "unknown"));
+      const std::string message =
+          "dlopen(libdxcore_amd64.so) failed: " +
+          (err ? std::string(err) : "unknown");
+      defyx_core::LogMessage(message);
+      SetLastError(message);
       return false;
     } else {
       defyx_core::LogMessage("Loaded libdxcore_amd64.so from default search path");
@@ -188,6 +214,7 @@ bool LoadCoreDll(const std::string& dllPath) {
   check("SetCacheDir", g_set_cache_dir);
   check("IsTunnelRunning", g_is_tunnel_running);
   defyx_core::LogMessage("libdxcore_amd64.so loaded and symbol lookup completed");
+  SetLastError("");
 
   return true;
 }
@@ -207,15 +234,19 @@ void UnloadCoreDll() {
     g_set_timezone = nullptr;
     g_get_flowline = nullptr;
     g_get_cached_flowline = nullptr;
+    g_decode_verify_flowline = nullptr;
     g_get_vpn_status = nullptr;
     g_set_progress_cb = nullptr;
     g_set_verbose = nullptr;
     g_free_string = nullptr;
-  g_set_connection_method = nullptr;
-  g_is_tunnel_running = nullptr;
+    g_set_connection_method = nullptr;
+    g_set_cache_dir = nullptr;
+    g_is_tunnel_running = nullptr;
 
-    // Clear progress handler
-    g_progress_handler = nullptr;
+    {
+      std::lock_guard<std::mutex> progress_lock(g_progress_mutex);
+      g_progress_handler = nullptr;
+    }
 
     dlclose(g_dx_dll);
     g_dx_dll = nullptr;
@@ -231,6 +262,11 @@ void UnloadCoreDll() {
   ::UnloadCoreDll();
 }
 
+std::string GetLastError() {
+  std::lock_guard<std::mutex> lock(g_error_mutex);
+  return g_last_error;
+}
+
 void EnableVerboseLogs(bool enable) {
   if (g_set_verbose) {
     g_set_verbose(enable ? 1 : 0);
@@ -238,7 +274,10 @@ void EnableVerboseLogs(bool enable) {
 }
 
 void RegisterProgressHandler(std::function<void(std::string)> handler) {
-  g_progress_handler = std::move(handler);
+  {
+    std::lock_guard<std::mutex> lock(g_progress_mutex);
+    g_progress_handler = std::move(handler);
+  }
   if (g_set_progress_cb) {
     g_set_progress_cb(&DxProgressC);
   }
@@ -254,11 +293,17 @@ bool StartVPN(const std::string& cacheDir, const std::string& flowLine, const st
     if (g_start_vpn) {
       int r = g_start_vpn(cacheDir.c_str(), flowLine.c_str(), pattern.c_str(), deepScan ? 1 : 0, healthCheck ? 1 : 0);
       defyx_core::LogMessage(std::string("StartVPN returned ") + (r != 0 ? "true" : "false"));
+      if (r == 0) {
+        SetLastError("DXcore StartVPN returned false");
+      } else {
+        SetLastError("");
+      }
       return r != 0;
     }
   } catch (...) {}
   (void)cacheDir; (void)flowLine; (void)pattern;
-  return true;
+  SetLastError("DXcore does not export StartVPN");
+  return false;
 }
 
 void StartTun2Socks(long long fd, const std::string& addr) {

--- a/linux/runner/defyx_core.h
+++ b/linux/runner/defyx_core.h
@@ -34,4 +34,5 @@ void RegisterProgressHandler(std::function<void(std::string)> handler);
 // Returns true if the shared library was loaded and entrypoints found.
 bool LoadCoreDll(const std::string& dllPath = "");
 void UnloadCoreDll();
+std::string GetLastError();
 } // namespace defyx_core


### PR DESCRIPTION
### Change Description

This PR adds an optional terminal-only Linux client for running DefyxVPN on
servers, SSH-only hosts, containers, and minimal installations.

`defyxvpn-cli` reuses the existing Linux DXcore library without linking Flutter,
GTK, Firebase, or display-server libraries. It runs in the foreground for shell
or systemd supervision. No Dart, GUI, or existing application code is changed.

#### Main changes

- Adds C++17 `connect`, `status`, and `disconnect` commands.
- Retrieves online, encrypted cached, or signed offline flowlines.
- Derives the default connection pattern from enabled labels in published order,
  matching the desktop client.
- Handles termination signals and cleans up DXcore and runtime state.
- Prevents duplicate instances for the same cache directory.
- Supports connection timeouts, deep scan, logging controls, custom paths, and
  environment variables.
- Adds configurable SOCKS5 bind address and port.
- Adds an in-process TCP relay for exposing DXcore's local SOCKS5 endpoint.
- Preserves TCP half-closes in both directions.
- Adds opt-in startup and periodic HTTPS data-path validation.
- Supports automatic connection-method failover at startup and runtime.
- Includes unit and integration tests, systemd examples, documentation, CI, and
  a Linux x86_64 artifact.

#### Networking and security

DXcore's `127.0.0.1:5000` SOCKS5 endpoint remains the default. To listen on a
different address or port, the CLI starts an in-process TCP relay:

```bash
defyxvpn-cli connect \
  --listen-address 0.0.0.0 \
  --listen-port 1080
```

The relay preserves TCP half-closes. An EOF from one direction is propagated
with `shutdown(SHUT_WR)` while the reverse response remains readable.

LAN exposure is opt-in and unauthenticated, so non-loopback binds produce a
warning. Addresses and ports are validated, `0.0.0.0:5000` is rejected because
it conflicts with DXcore's internal listener, and simultaneous relay
connections are limited to 256.

A LAN-facing port should be restricted to trusted clients with the host or
network firewall.

The CLI does **not** create a TUN interface, modify system routes, install
certificates, or change system proxy settings.

#### HTTPS health validation and failover

DXcore can report `VPN connected` even when a selected route cannot transfer a
complete HTTPS response. Small connectivity checks may also pass while larger
TLS responses are truncated.

When `--health-check` is enabled, the CLI:

1. Starts one enabled connection-method label at a time in published order.
2. Keeps the public status at `checking` after DXcore reports connected.
3. Downloads a deterministic 64 KiB HTTPS response through the actual SOCKS5
   data path.
4. Requires curl success, an HTTP 2xx response, and the configured minimum byte
   count.
5. Rejects truncated responses, TLS errors, timeouts, and non-2xx responses.
6. Stops an unhealthy startup method and tries the next enabled label.
7. Reports the proxy as connected only after the startup probe passes.
8. Repeats the same end-to-end probe at a configurable runtime interval.
9. Resets the runtime failure counter whenever a probe succeeds.
10. Fails over after the configured number of consecutive runtime failures.

Example:

```bash
defyxvpn-cli connect \
  --pattern "Hive,Xray,Outline,Masque" \
  --listen-address 0.0.0.0 \
  --listen-port 1080 \
  --health-check \
  --health-check-interval 60 \
  --health-check-failures 2 \
  --timeout 90
```

The defaults are:

- Health-check URL:
  `https://speed.cloudflare.com/__down?bytes=65536`
- Minimum complete response: `65536` bytes
- Per-check timeout: `20` seconds
- Runtime interval: `60` seconds
- Consecutive failures before failover: `2`

These settings are configurable through command-line arguments or environment
variables:

```text
--health-check-url              DEFYX_HEALTH_CHECK_URL
--health-check-min-bytes        DEFYX_HEALTH_CHECK_MIN_BYTES
--health-check-timeout          DEFYX_HEALTH_CHECK_TIMEOUT
--health-check-interval         DEFYX_HEALTH_CHECK_INTERVAL
--health-check-failures         DEFYX_HEALTH_CHECK_FAILURES
```

Setting `--health-check-interval 0` keeps startup validation enabled but
disables the CLI's periodic probes.

The probe invokes `curl` directly with `posix_spawnp` and fixed arguments,
without a shell. It disables user curl configuration, resolves DNS through the
SOCKS5 proxy, follows HTTPS redirects only, and uses the operating system's CA
certificate store.

DXcore's internal health monitor remains enabled independently.

#### Runtime failure behavior

A DXcore `failed` or unexpected `stopped` event immediately marks the current
method unhealthy without waiting for the next periodic probe.

During runtime failover, the CLI:

1. Stops the current DXcore attempt.
2. Clears the previous connection state.
3. Resets the connection timeout for the new attempt.
4. Starts the next enabled connection method.

If no methods remain, the CLI exits with code `4`. The provided systemd service
uses `Restart=on-failure`, waits five seconds, and starts again from the first
method.

---

### Related Platforms

- [ ] Android
- [ ] iOS
- [ ] iPad
- [ ] Windows
- [x] Linux
- [ ] Android TV
- [ ] OpenWrt

---

### Verification Checklist

- [x] Project builds successfully
- [x] CLI runs without crashes on the tested platform
- [x] VPN connection works correctly
- [x] SOCKS5 proxy works from another LAN device
- [x] HTTPS traffic works through the proxy
- [x] Startup method failover works
- [x] Periodic runtime monitoring works
- [x] Runtime failure handling has integration coverage
- [x] No obvious regressions observed in the tested CLI scope
- [x] Documentation updated
- [x] Added or updated unit and integration tests
- [x] Checked security and edge cases

#### Automated verification

- Built with GCC 13.3, CMake, and Ninja.
- Tested with `Release` and `RelWithDebInfo` configurations.
- Built with all configured compiler warnings enabled.
- CTest result: **2/2 passed** using the optimized Linux binary.
- Tests cover option parsing, flowline handling, runtime status, HTTPS health
  checks, TCP relay half-closes, startup method failover, configurable periodic
  checks, consecutive failure counting, and runtime failure exit code `4`.
- The runtime integration test passes startup validation, simulates two
  consecutive periodic failures, and verifies the expected failover messages
  and exit status.

The GUI and non-Ubuntu distributions were not exercised. The available
production DXcore library currently limits the artifact to Linux x86_64.
